### PR TITLE
Fix build by using python3 from $PATH

### DIFF
--- a/c64disasm/combine.py
+++ b/c64disasm/combine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import html, re, os
 

--- a/c64io/combine.py
+++ b/c64io/combine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re, os
 import pprint

--- a/c64mem/combine.py
+++ b/c64mem/combine.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import re, os
 import pprint

--- a/c64mem/format.py
+++ b/c64mem/format.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import os

--- a/charset/charset2png.py
+++ b/charset/charset2png.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 from PIL import Image, ImageDraw

--- a/charset/compare.py
+++ b/charset/compare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 import binascii

--- a/charset/generate.py
+++ b/charset/generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 

--- a/kernal/generate.py
+++ b/kernal/generate.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import markdown
 import re


### PR DESCRIPTION
Building c64ref on my system fails:

```
$ bash -x generate.sh
+ cd c64disasm
+ ./combine.py
+ cd c64mem
+ ./combine.py
Traceback (most recent call last):
  File "./combine.py", line 5, in <module>
    import markdown
ModuleNotFoundError: No module named 'markdown'
+ cd kernal
+ ./generate.py
Traceback (most recent call last):
  File "./generate.py", line 3, in <module>
    import markdown
ModuleNotFoundError: No module named 'markdown'
+ cd charset
+ ./generate.py
$
```

It fails because [`markdown`](https://pypi.org/project/Markdown/) is not part of the Python standard library.  I installed it but the build still failed because the scripts are hardcoded to use `/usr/bin/python3` and the Python environment where I installed it is in a different location.

I prefer not to install packages into my system's Python environment, so I have a different Python environment earlier in my `$PATH` that I use instead.  Many people run Python this way, e.g. users of `virtualenv`/`venv` and Homebrew.  

This PR changes the scripts to run `python3` from `$PATH` so c64ref can be built on such systems.