### PR TITLE
Fix C flag for ASL to be consistent with documentation and behavior

### DIFF
--- a/Source/6502/cpu_6502.txt
+++ b/Source/6502/cpu_6502.txt
@@ -88,7 +88,7 @@ TYA  Transfer Y to Accumulator
 [operations]
 ADC  arith  NV----ZC  A + M + C → A, C
 AND  logic  N-----Z-  A ∧ M → A
-ASL  shift  N-----Z0  C ← /M7...M0/ ← 0
+ASL  shift  N-----ZC  C ← /M7...M0/ ← 0
 BCC  bra    --------  Branch on C = 0
 BCS  bra    --------  Branch on C = 1
 BEQ  bra    --------  Branch on Z = 1
@@ -915,7 +915,7 @@ LSR  Logical Shift Right
      The shift right instruction either affects the accumulator by shift­ing it right 1 or is a read/modify/write instruction which changes a speci­fied memory location but does not affect any internal registers. The shift right does not affect the overflow flag. The N flag is always reset. The Z flag is set if the result of the shift is 0 and reset otherwise. The carry is set equal to bit 0 of the input.
 
 ASL  Arithmetic Shift Left
-     The shift left instruction shifts either the accumulator or the address memory location 1 bit to the left, with the bit 0 always being set to 0 and the bit 7 output always being contained in the carry flag. ASL either shifts the accumulator left 1 bit or is a read/modify/write instruction that affects only memory.
+     The shift left instruction shifts either the accumulator or the address memory location 1 bit to the left, with the bit 0 always being set to 0 and the the input bit 7 being stored in the carry flag. ASL either shifts the accumulator left 1 bit or is a read/modify/write instruction that affects only memory.
      The instruction does not affect the overflow bit, sets N equal to the result bit 7 (bit 6 in the input), sets Z flag if the result is equal to 0, otherwise resets Z and stores the input bit 7 in the carry flag.
 
 ROL Rotate Left


### PR DESCRIPTION
The page currently says that C flag becomes 0.