### PR TITLE
Fixed an omission in kernal_ptg.txt. CHKIN clobbers the Y register

### DIFF
--- a/Source/kernal/kernal_prg.txt
+++ b/Source/kernal/kernal_prg.txt
@@ -68,7 +68,7 @@ $FFC6  CHKIN   Open a channel for input
                * Preparatory routines: (OPEN)
                * Error returns: 0,3,5,6 (See READST)
                * Stack requirements: None
-               * Registers affected: A, X
+               * Registers affected: A, X, Y
                
                
                  **Description**: Any logical file that has already been opened by the


### PR DESCRIPTION
Fixed an omission in kernal_ptg.txt. CHKIN clobbers the Y register and should be documented, for example, as kernal_ct.txt does: `.Y destroyed`