### PR TITLE
fix RTS typo: Subroutme > Subroutine

### DIFF
--- a/Source/6502/cpu_6502.txt
+++ b/Source/6502/cpu_6502.txt
@@ -869,7 +869,7 @@ JSR  Jump To Subroutine
      This instruction transfers control of the program counter to a subroutine location but leaves a return pointer on the stack to allow the user to return to perform the next instruction in the main program after the subroutine is complete. To accomplish this, JSR instruction stores the program counter address which points to the last byte of the jump instruc­ tion onto the stack using the stack pointer. The stack byte contains the program count high first, followed by program count low. The JSR then transfers the addresses following the jump instruction to the program counter low and the program counter high, thereby directing the program to begin at that new address.
       The JSR instruction affects no flags, causes the stack pointer to be decremented by 2 and substitutes new values into the program counter low and the program counter high.
 
-RTS  Return From Subroutme
+RTS  Return From Subroutine
       This instruction loads the program count low and program count high from the stack into the program counter and increments the program counter so that it points to the instruction following the JSR. The stack pointer is adjusted by incrementing it twice.
       The RTS instruction does not affect any flags and affects only PCL and PCH.
 


### PR DESCRIPTION
- Fixes a typo in the `RTS` instruction card:
  - [Before](https://github.com/mist64/c64ref/blob/4274bd8782c5d3b18c68e6b9479b0ec751eb96b1/Source/6502/cpu_6502.txt#L872): `RTS  Return From Subroutme`
  - This PR: `RTS  Return From Subroutine`
- Tested with local Deno webserver:

    
    ![372BA7C4-4476-4B19-A912-CB50FA6535A2](https://github.com/mist64/c64ref/assets/13394541/5c73f660-555a-4d60-85b8-445358fbe632)
