### PR TITLE
added [a8],Y (Direct Page Indirect Long Y-Indexed) to the known addressing modes

### DIFF
--- a/src/6502/script.js
+++ b/src/6502/script.js
@@ -31,6 +31,7 @@ const all_sorted_addmodes = [
 	'(a8),Y',
 	'(a8),Z',
 	'[a8]',
+	'[a8],Y',
 	'[a16]',
 	'a24',
 	'a24,X',


### PR DESCRIPTION
<img width="451" alt="Screenshot 2024-07-09 at 13 34 58" src="https://github.com/mist64/c64ref/assets/772311/f3438e48-b3ad-4431-a88f-d9b7a9e32fe2">

fixes #47 