### PR TITLE
Fixed typos

### DIFF
--- a/src/6502/cpu_6502.txt
+++ b/src/6502/cpu_6502.txt
@@ -741,7 +741,7 @@ SEC  Set Carry Flag
      This instruction affects no registers in the microprocessor and no flags other than the carry flag which is set.
 
 CLC  Clear Carry Flag
-     This instruction initializes the carry flag to a 0. This op­eration should normally precede an ADC loop. It is also useful when used with a R0L instruction to clear a bit in memory.
+     This instruction initializes the carry flag to a 0. This operation should normally precede an ADC loop. It is also useful when used with a ROL instruction to clear a bit in memory.
      This instruction affects no registers in the microprocessor and no flags other than the carry flag which is reset.
 
 SEI  Set Interrupt Disable
@@ -761,7 +761,7 @@ CLD  Clear Decimal Mode
      CLD affects no registers in the microprocessor and no flags other than the decimal mode flag which is set to a 0.
 
 CLV  Clear Overflow Flag
-     This instruction clears the overflow flag to a 0. This com­mand is used in conjunction with the set overflow pin which can change the state of the overflow flag with an external signal.
+     This instruction clears the overflow flag to a 0. This command is used in conjunction with the set overflow pin which can change the state of the overflow flag with an external signal.
      CLV affects no registers in the microprocessor and no flags other than the overflow flag which is set to a 0.
 
 JMP  Jump to New Location
@@ -785,7 +785,7 @@ BCS  Branch on Carry Set
 
 BEQ  Branch on Result Zero
      This instruction could also be called "Branch on Equal."
-     It takes a conditional branch whenever the Z flag is on or the previ­ous result is equal to 0.
+     It takes a conditional branch whenever the Z flag is on or the previous result is equal to 0.
      BEQ does not affect any of the flags or registers other than the program counter and only then when the Z flag is set.
 
 BNE  Branch on Result Not Zero
@@ -838,7 +838,7 @@ DEX  Decrement Index Register X By One
      DEX does not affect the carry or overflow flag, it sets the N flag if it has bit 7 on as a result of the decrement, otherwise it resets the N flag; sets the Z flag if X is a 0 as a result of the decrement, otherwise it resets the Z flag.
 
 DEY  Decrement Index Register Y By One
-     This instruction subtracts one from the current value in the in­dex register Y and stores the result into the index register Y. The result does not affect or consider carry so that the value in the index register Y is decremented to 0 and then through 0 to FF.
+     This instruction subtracts one from the current value in the index register Y and stores the result into the index register Y. The result does not affect or consider carry so that the value in the index register Y is decremented to 0 and then through 0 to FF.
      Decrement Y does not affect the carry or overflow flags; if the Y register contains bit 7 on as a result of the decrement the N flag is set, otherwise the N flag is reset. If the Y register is 0 as a result of the decrement, the Z flag is set otherwise the Z flag is reset. This instruction only affects the index register Y.
 
 CPX  Compare Index Register X To Memory
@@ -846,12 +846,12 @@ CPX  Compare Index Register X To Memory
      The CPX instruction does not affect any register in the machine; it also does not affect the overflow flag. It causes the carry to be set on if the absolute value of the index register X is equal to or greater than the data from memory. If the value of the memory is greater than the content of the index register X, carry is reset. If the results of the subtraction contain a bit 7, then the N flag is set, if not, it is reset. If the value in memory is equal to the value in index register X, the Z flag is set, otherwise it is reset.
 
 CPY  Compare Index Register Y To Memory
-     This instruction performs a two's complement subtraction between the index register Y and the specified memory location. The results of the subtraction are not stored anywhere. The instruction is strict­ly used to set the flags.
+     This instruction performs a two's complement subtraction between the index register Y and the specified memory location. The results of the subtraction are not stored anywhere. The instruction is strictly used to set the flags.
      CPY affects no registers in the microprocessor and also does not affect the overflow flag. If the value in the index register Y is equal to or greater than the value in the memory, the carry flag will be set, otherwise it will be cleared. If the results of the subtraction contain bit 7 on the N bit will be set, otherwise it will be cleared. If the value in the index register Y and the value in the memory are equal, the zero flag will be set, otherwise it will be cleared.
 
 TAX  Transfer Accumulator To Index X
-     This instruction takes the value from accumulator A and trans­ fers or loads it into the index register X without disturbing the content of the accumulator A.
-     TAX only affects the index register X, does not affect the carry or overflow flags. The N flag is set if the resultant value in the index register X has bit 7 on, otherwise N is reset. The Z bit is set if the content of the register X is 0 as a result of the opera­tion, otherwise it is reset.
+     This instruction takes the value from accumulator A and transfers or loads it into the index register X without disturbing the content of the accumulator A.
+     TAX only affects the index register X, does not affect the carry or overflow flags. The N flag is set if the resultant value in the index register X has bit 7 on, otherwise N is reset. The Z bit is set if the content of the register X is 0 as a result of the operation, otherwise it is reset.
 
 TXA  Transfer Index X To Accumulator
      This instruction moves the value that is in the index register X to the accumulator A without disturbing the content of the index register X.
@@ -866,7 +866,7 @@ TYA  Transfer Index Y To Accumulator
      TYA does not affect any other register other than the accumulator and does not affect the carry or overflow flag. If the result in the accumulator A has bit 7 on, the N flag is set, otherwise it is reset. If the resultant value in the accumulator A is 0, then the Z flag is set, otherwise it is reset.
 
 JSR  Jump To Subroutine
-     This instruction transfers control of the program counter to a subroutine location but leaves a return pointer on the stack to allow the user to return to perform the next instruction in the main program after the subroutine is complete. To accomplish this, JSR instruction stores the program counter address which points to the last byte of the jump instruc­tion onto the stack using the stack pointer. The stack byte contains the program count high first, followed by program count low. The JSR then transfers the addresses following the jump instruction to the program counter low and the program counter high, thereby directing the program to begin at that new address.
+     This instruction transfers control of the program counter to a subroutine location but leaves a return pointer on the stack to allow the user to return to perform the next instruction in the main program after the subroutine is complete. To accomplish this, JSR instruction stores the program counter address which points to the last byte of the jump instruction onto the stack using the stack pointer. The stack byte contains the program count high first, followed by program count low. The JSR then transfers the addresses following the jump instruction to the program counter low and the program counter high, thereby directing the program to begin at that new address.
       The JSR instruction affects no flags, causes the stack pointer to be decremented by 2 and substitutes new values into the program counter low and the program counter high.
 
 RTS  Return From Subroutine
@@ -891,11 +891,11 @@ TSX  Transfer Stack Pointer To Index X
      TSX does not affect the carry or overflow flags. It sets N if bit 7 is on in index X as a result of the instruction, otherwise it is reset. If index X is zero as a result of the TSX, the Z flag is set, other­ wise it is reset. TSX changes the value of index X, making it equal to the content of the stack pointer.
 
 PHP  Push Processor Status On Stack
-     This instruction transfers the contents of the processor status reg­ister unchanged to the stack, as governed by the stack pointer.
-     The PHP instruction affects no registers or flags in the micropro­cessor.
+     This instruction transfers the contents of the processor status register unchanged to the stack, as governed by the stack pointer.
+     The PHP instruction affects no registers or flags in the microprocessor.
 
 PLP  Pull Processor Status From Stack
-     This instruction transfers the next value on the stack to the Proces­sor Status register, thereby changing all of the flags and setting the mode switches to the values from the stack.
+     This instruction transfers the next value on the stack to the Processor Status register, thereby changing all of the flags and setting the mode switches to the values from the stack.
      The PLP instruction affects no registers in the processor other than the status register. This instruction could affect all flags in the status register.
 
 RTI  Return From Interrupt
@@ -907,12 +907,12 @@ JMP  JMP Indirect
      It affects only the program counter in the microprocessor and affects no flags in the status register.
 
 BRK  Break Command
-     The break command causes the microprocessor to go through an inter­rupt sequence under program control. This means that the program counter of the second byte after the BRK. is automatically stored on the stack along with the processor status at the beginning of the break instruction. The microprocessor then transfers control to the interrupt vector.
+     The break command causes the microprocessor to go through an interrupt sequence under program control. This means that the program counter of the second byte after the BRK. is automatically stored on the stack along with the processor status at the beginning of the break instruction. The microprocessor then transfers control to the interrupt vector.
      Other than changing the program counter, the break instruction changes no values in either the registers or the flags.
 
 LSR  Logical Shift Right
      This instruction shifts either the accumulator or a specified memory location 1 bit to the right, with the higher bit of the result always being set to 0, and the low bit which is shifted out of the field being stored in the carry flag.
-     The shift right instruction either affects the accumulator by shift­ing it right 1 or is a read/modify/write instruction which changes a speci­fied memory location but does not affect any internal registers. The shift right does not affect the overflow flag. The N flag is always reset. The Z flag is set if the result of the shift is 0 and reset otherwise. The carry is set equal to bit 0 of the input.
+     The shift right instruction either affects the accumulator by shifting it right 1 or is a read/modify/write instruction which changes a specified memory location but does not affect any internal registers. The shift right does not affect the overflow flag. The N flag is always reset. The Z flag is set if the result of the shift is 0 and reset otherwise. The carry is set equal to bit 0 of the input.
 
 ASL  Arithmetic Shift Left
      The shift left instruction shifts either the accumulator or the address memory location 1 bit to the left, with the bit 0 always being set to 0 and the input bit 7 being stored in the carry flag. ASL either shifts the accumulator left 1 bit or is a read/modify/write instruction that affects only memory.
@@ -920,15 +920,15 @@ ASL  Arithmetic Shift Left
 
 ROL Rotate Left
      The rotate left instruction shifts either the accumulator or addressed memory left 1 bit, with the input carry being stored in bit 0 and with the input bit 7 being stored in the carry flags.
-     The ROL instruction either shifts the accumulator left 1 bit and stores the carry in accumulator bit 0 or does not affect the internal reg­isters at all. The ROL instruction sets carry equal to the input bit 7, sets N equal to the input bit 6 , sets the Z flag if the result of the ro­tate is 0, otherwise it resets Z and does not affect the overflow flag at all.
+     The ROL instruction either shifts the accumulator left 1 bit and stores the carry in accumulator bit 0 or does not affect the internal registers at all. The ROL instruction sets carry equal to the input bit 7, sets N equal to the input bit 6 , sets the Z flag if the result of the rotate is 0, otherwise it resets Z and does not affect the overflow flag at all.
 
 ROR  Rotate Right
      The rotate right instruction shifts either the accumulator or addressed memory right 1 bit with bit 0 shifted into the carry and carry shifted into bit 7.
-     The ROR instruction either shifts the accumulator right 1 bit and stores the carry in accumulator bit 7 or does not affect the internal regis­ters at all. The ROR instruction sets carry equal to input bit 0, sets N equal to the input carry and sets the Z flag if the result of the rotate is 0; otherwise it resets Z and does not affect the overflow flag at all.
+     The ROR instruction either shifts the accumulator right 1 bit and stores the carry in accumulator bit 7 or does not affect the internal registers at all. The ROR instruction sets carry equal to input bit 0, sets N equal to the input carry and sets the Z flag if the result of the rotate is 0; otherwise it resets Z and does not affect the overflow flag at all.
      (Available on Microprocessors after June, 1976)
 
 INC  Increment Memory By One
-     This instruction adds 1 to the contents of the addressed memory loca­tion.
+     This instruction adds 1 to the contents of the addressed memory location.
      The increment memory instruction does not affect any internal registers and does not affect the carry or overflow flags. If bit 7 is on as the result of the increment,N is set, otherwise it is reset; if the increment causes the result to become 0, the Z flag is set on, otherwise it is reset.
 
 DEC  Decrement Memory By One
@@ -975,7 +975,7 @@ DCP  Decrement Memory By One then Compare with Accumulator
      The DCP instruction does not affect any internal register in the microprocessor. It does not affect the overflow flag. Z flag is set on an equal comparison, reset otherwise; the N flag is set or reset by the result bit 7, the carry flag is set when the result in memory is less than or equal to the accumulator, reset when it is greater than the accumulator.
 
 ISC  Increment Memory By One then SBC then Subtract Memory from Accumulator with Borrow
-     This undocumented instruction adds 1 to the contents of the addressed memory loca­tion. It then subtracts the value of the result in memory and borrow from the value of the accumulator, using two's complement arithmetic, and stores the result in the accumulator.
+     This undocumented instruction adds 1 to the contents of the addressed memory location. It then subtracts the value of the result in memory and borrow from the value of the accumulator, using two's complement arithmetic, and stores the result in the accumulator.
      This instruction affects the accumulator. The carry flag is set if the result is greater than or equal to 0. The carry flag is reset when the result is less than 0, indicating a borrow. The over­flow flag is set when the result exceeds +127 or -127, otherwise it is reset. The negative flag is set if the result in the accumulator has bit 7 on, otherwise it is reset. The Z flag is set if the result in the accumulator is 0, otherwise it is reset.
      ## XXX are the flags correctly described for decimal mode?
 

--- a/src/6502/cpu_65ce02.txt
+++ b/src/6502/cpu_65ce02.txt
@@ -417,15 +417,15 @@ AUG  Augment
      The AUG instruction is a 4-byte NOP, and reserved for future expansion.
 
 BSR  Branch to Subroutine
-     The BSR Branch to SubRoutine instruction pushes the two program counter  bytes PCH and PCL onto the stack. It then adds the word-relative signed offset to the program counter. The relative offset is referenced to the address of the BSR opcode + 2, hence, it is relative to the third byte of the three-byte BSR instruction. The return address, on the stack, also points to this address. This was done to make it compatible with the RTS functionality, and to be consistant will other word-relative operations.
+     The BSR Branch to SubRoutine instruction pushes the two program counter  bytes PCH and PCL onto the stack. It then adds the word-relative signed offset to the program counter. The relative offset is referenced to the address of the BSR opcode + 2, hence, it is relative to the third byte of the three-byte BSR instruction. The return address, on the stack, also points to this address. This was done to make it compatible with the RTS functionality, and to be consistent will other word-relative operations.
 
 CLE  Clear Extend Disable Flag
      This instruction initializes the extend disable to a 0. This sets the stack pointer to 16 bit mode.
      It affects no registers in the microprocessor and no flags other than the extend disable which is cleared.
 
 CPZ  Compare Index Register Z To Memory
-     This instruction performs a two's complement subtraction between the index register Z and the specified memory location. The results of the subtraction are not stored anywhere. The instruction is strict­ly used to set the flags.
-     CPZ affects no registers in the microprocessor and also does not affect the overflow flag. If the value in the index register Z is equal to or greater than the value in the memory, the carry flag will be set, otherwise it will be cleared. If the results of the subtract- tion contain bit 7 on the N bit will be set, otherwise it will be cleared. If the value in the index register Z and the value in the memory are equal, the zero flag will be set, otherwise it will be cleared.
+     This instruction performs a two's complement subtraction between the index register Z and the specified memory location. The results of the subtraction are not stored anywhere. The instruction is strictly used to set the flags.
+     CPZ affects no registers in the microprocessor and also does not affect the overflow flag. If the value in the index register Z is equal to or greater than the value in the memory, the carry flag will be set, otherwise it will be cleared. If the results of the subtraction contain bit 7 on the N bit will be set, otherwise it will be cleared. If the value in the index register Z and the value in the memory are equal, the zero flag will be set, otherwise it will be cleared.
 
 ## TODO
 DEW  Decrement Word

--- a/src/c64disasm/c64disasm_en.txt
+++ b/src/c64disasm/c64disasm_en.txt
@@ -1307,7 +1307,7 @@
                                 *** check and evaluate numeric digit
 .,AA1D B1 22    LDA ($22),Y     get byte from string
 .,AA1F 20 80 00 JSR $0080       clear Cb if numeric. this call should be to $84
-                                as the code from $80 first comapres the byte with
+                                as the code from $80 first compares the byte with
                                 [SPACE] and does a BASIC increment and get if it is
 .,AA22 90 03    BCC $AA27       branch if numeric
 .,AA24 4C 48 B2 JMP $B248       do illegal quantity error then warm start
@@ -1666,7 +1666,7 @@
 .,AC8E 20 C2 A9 JSR $A9C2       assign value to numeric variable
 .,AC91 20 79 00 JSR $0079       scan memory
 .,AC94 F0 07    BEQ $AC9D       branch if ":" or [EOL]
-.,AC96 C9 2C    CMP #$2C        comparte with ","
+.,AC96 C9 2C    CMP #$2C        compare with ","
 .,AC98 F0 03    BEQ $AC9D       branch if ","
 .,AC9A 4C 4D AB JMP $AB4D       else go do bad input routine
                                 string terminated with ":", "," or $00
@@ -1773,7 +1773,7 @@
 .,AD70 BD 11 01 LDA $0111,X     get BASIC execute pointer high byte
 .,AD73 85 7B    STA $7B         save BASIC execute pointer high byte
 .,AD75 4C AE A7 JMP $A7AE       go do interpreter inner loop
-                                NEXT loop comlete
+                                NEXT loop complete
 .,AD78 8A       TXA             stack copy to A
 .,AD79 69 11    ADC #$11        add $12, $11 + carry, to dump FOR structure
 .,AD7B AA       TAX             copy back to index
@@ -1795,11 +1795,11 @@
                                 type match check, set C for string, clear C for numeric
 .,AD90 24 0D    BIT $0D         test data type flag, $FF = string, $00 = numeric
 .,AD92 30 03    BMI $AD97       branch if string
-.,AD94 B0 03    BCS $AD99       if destiantion is numeric do type missmatch error
+.,AD94 B0 03    BCS $AD99       if destination is numeric do type mismatch error
 .,AD96 60       RTS             
 .,AD97 B0 FD    BCS $AD96       exit if destination is string
-                                do type missmatch error
-.,AD99 A2 16    LDX #$16        error code $16, type missmatch error
+                                do type mismatch error
+.,AD99 A2 16    LDX #$16        error code $16, type mismatch error
 .,AD9B 4C 37 A4 JMP $A437       do error #X then warm start
 
                                 *** evaluate expression
@@ -1816,7 +1816,7 @@
 .,ADAE 20 FB A3 JSR $A3FB       check room on stack for A*2 bytes
 .,ADB1 20 83 AE JSR $AE83       get value from line
 .,ADB4 A9 00    LDA #$00        clear A
-.,ADB6 85 4D    STA $4D         clear comparrison evaluation flag
+.,ADB6 85 4D    STA $4D         clear comparison evaluation flag
 .,ADB8 20 79 00 JSR $0079       scan memory
 .,ADBB 38       SEC             set carry for subtract
 .,ADBC E9 B1    SBC #$B1        subtract the token for ">"
@@ -1827,13 +1827,13 @@
 .,ADC4 C9 01    CMP #$01        compare with token for =
 .,ADC6 2A       ROL             *2, b0 = carry (=1 if token was = or <)
 .,ADC7 49 01    EOR #$01        toggle b0
-.,ADC9 45 4D    EOR $4D         EOR with comparrison evaluation flag
-.,ADCB C5 4D    CMP $4D         compare with comparrison evaluation flag
+.,ADC9 45 4D    EOR $4D         EOR with comparison evaluation flag
+.,ADCB C5 4D    CMP $4D         compare with comparison evaluation flag
 .,ADCD 90 61    BCC $AE30       if < saved flag do syntax error then warm start
-.,ADCF 85 4D    STA $4D         save new comparrison evaluation flag
+.,ADCF 85 4D    STA $4D         save new comparison evaluation flag
 .,ADD1 20 73 00 JSR $0073       increment and scan memory
 .,ADD4 4C BB AD JMP $ADBB       go do next character
-.,ADD7 A6 4D    LDX $4D         get comparrison evaluation flag
+.,ADD7 A6 4D    LDX $4D         get comparison evaluation flag
 .,ADD9 D0 2C    BNE $AE07       branch if compare function
 .,ADDB B0 7B    BCS $AE58       go do functions
                                 else was < TK_GT so is operator or lower
@@ -1871,7 +1871,7 @@
 .,AE11 C6 7A    DEC $7A         decrement BASIC execute pointer low byte
 .,AE13 A0 1B    LDY #$1B        
                                 set offset to = operator precedence entry
-.,AE15 85 4D    STA $4D         save new comparrison evaluation flag
+.,AE15 85 4D    STA $4D         save new comparison evaluation flag
 .,AE17 D0 D7    BNE $ADF0       branch always
 .,AE19 D9 80 A0 CMP $A080,Y     compare with stacked function precedence
 .,AE1C B0 48    BCS $AE66       if A >=, pop FAC2 and return
@@ -1885,7 +1885,7 @@
                                 now push sign, round FAC1 and put on stack
 .,AE28 20 33 AE JSR $AE33       function will return here, then the next RTS will call
                                 the function
-.,AE2B A5 4D    LDA $4D         get comparrison evaluation flag
+.,AE2B A5 4D    LDA $4D         get comparison evaluation flag
 .,AE2D 4C A9 AD JMP $ADA9       continue evaluating expression
 .,AE30 4C 08 AF JMP $AF08       do syntax error then warm start
 .,AE33 A5 66    LDA $66         get FAC1 sign (b7)
@@ -2099,7 +2099,7 @@
 .,AF66 C8       INY             increment index
 .,AF67 B1 64    LDA ($64),Y     get integer variable high byte
 .,AF69 A8       TAY             copy to Y
-.,AF6A 8A       TXA             copy loa byte to A
+.,AF6A 8A       TXA             copy low byte to A
 .,AF6B 4C 91 B3 JMP $B391       convert fixed integer AY to float FAC1 and return
                                 variable name set-up, variable is float
 .,AF6E 20 14 AF JSR $AF14       check address range
@@ -2222,7 +2222,7 @@
                                 do string < compare
 .,B02E A9 00    LDA #$00        clear byte
 .,B030 85 0D    STA $0D         clear data type flag, $FF = string, $00 = numeric
-.,B032 C6 4D    DEC $4D         clear < bit in comparrison evaluation flag
+.,B032 C6 4D    DEC $4D         clear < bit in comparison evaluation flag
 .,B034 20 A6 B6 JSR $B6A6       pop string off descriptor stack, or from top of string
                                 space returns with A = length, X = pointer low byte,
                                 Y = pointer high byte
@@ -2620,9 +2620,9 @@
 .,B292 AA       TAX             copy low byte to X
 .,B293 68       PLA             pull dimension size high byte
 .,B294 69 00    ADC #$00        add carry to high byte
-.,B296 C8       INY             incement index to dimension size high byte
+.,B296 C8       INY             increment index to dimension size high byte
 .,B297 91 5F    STA ($5F),Y     save dimension size high byte
-.,B299 C8       INY             incement index to dimension size low byte
+.,B299 C8       INY             increment index to dimension size low byte
 .,B29A 8A       TXA             copy dimension size low byte
 .,B29B 91 5F    STA ($5F),Y     save dimension size low byte
 .,B29D 20 4C B3 JSR $B34C       compute array size
@@ -2643,7 +2643,7 @@
 .,B2B9 20 08 A4 JSR $A408       check available memory, do out of memory error if no room
 .,B2BC 85 31    STA $31         set end of arrays low byte
 .,B2BE 84 32    STY $32         set end of arrays high byte
-                                now the aray is created we need to zero all the elements in it
+                                now the array is created we need to zero all the elements in it
 .,B2C0 A9 00    LDA #$00        clear A for array clear
 .,B2C2 E6 72    INC $72         increment array size high byte, now block count
 .,B2C4 A4 71    LDY $71         get array size low byte, now index to block
@@ -2667,7 +2667,7 @@
 .,B2E5 A5 0C    LDA $0C         get default DIM flag
 .,B2E7 D0 62    BNE $B34B       exit if this was a DIM command
                                 else, find element
-.,B2E9 C8       INY             set index to # of dimensions, the dimension indeces
+.,B2E9 C8       INY             set index to # of dimensions, the dimension indexes
                                 are on the stack and will be removed as the position
                                 of the array element is calculated
 .,B2EA B1 5F    LDA ($5F),Y     get array's dimension count
@@ -3109,7 +3109,7 @@
 .,B5A6 65 22    ADC $22         add pointer low byte
 .,B5A8 85 22    STA $22         save pointer low byte
 .,B5AA 90 02    BCC $B5AE       branch if no rollover
-.,B5AC E6 23    INC $23         else increment pointer hgih byte
+.,B5AC E6 23    INC $23         else increment pointer high byte
 .,B5AE A6 23    LDX $23         get pointer high byte
 .,B5B0 E4 59    CPX $59         compare pointer high byte with end of this array high byte
 .,B5B2 D0 04    BNE $B5B8       branch if not there yet
@@ -4132,12 +4132,12 @@
                                 round FAC1 (no check)
 .,BC23 20 6F B9 JSR $B96F       increment FAC1 mantissa
 .,BC26 D0 F2    BNE $BC1A       branch if no overflow
-.,BC28 4C 38 B9 JMP $B938       nornalise FAC1 for C=1 and return
+.,BC28 4C 38 B9 JMP $B938       normalise FAC1 for C=1 and return
 
                                 *** get FAC1 sign
                                 return A = $FF, Cb = 1/-ve A = $01, Cb = 0/+ve, A = $00, Cb = ?/0
 .,BC2B A5 61    LDA $61         get FAC1 exponent
-.,BC2D F0 09    BEQ $BC38       exit if zero (allready correct SGN(0)=0)
+.,BC2D F0 09    BEQ $BC38       exit if zero (already correct SGN(0)=0)
 
                                 *** return A = $FF, Cb = 1/-ve A = $01, Cb = 0/+ve
                                 no = 0 check
@@ -4253,7 +4253,7 @@
                                 *** perform INT()
 .,BCCC A5 61    LDA $61         get FAC1 exponent
 .,BCCE C9 A0    CMP #$A0        compare with max int
-.,BCD0 B0 20    BCS $BCF2       exit if >= (allready int, too big for fractional part!)
+.,BCD0 B0 20    BCS $BCF2       exit if >= (already int, too big for fractional part!)
 .,BCD2 20 9B BC JSR $BC9B       convert FAC1 floating to fixed
 .,BCD5 84 70    STY $70         save FAC1 rounding byte
 .,BCD7 A5 66    LDA $66         get FAC1 sign (b7)
@@ -5210,7 +5210,7 @@
 .,E3E5 95 73    STA $73,X       save the byte in page zero
 .,E3E7 CA       DEX             decrement the count
 .,E3E8 10 F8    BPL $E3E2       loop if not all done
-                                clear descriptors, strings, program area and mamory pointers
+                                clear descriptors, strings, program area and memory pointers
 .,E3EA A9 03    LDA #$03        set the step size, collecting descriptors
 .,E3EC 85 53    STA $53         save the garbage collection step size
 .,E3EE A9 00    LDA #$00        clear A
@@ -5295,7 +5295,7 @@
 .,E4AD 48       PHA             save the flag byte
 .,E4AE 20 C9 FF JSR $FFC9       open channel for output
 .,E4B1 AA       TAX             copy the returned flag byte
-.,E4B2 68       PLA             restore the alling flag byte
+.,E4B2 68       PLA             restore the calling flag byte
 .,E4B3 90 01    BCC $E4B6       if there is no error skip copying the error flag
 .,E4B5 8A       TXA             else copy the error flag
 .,E4B6 60       RTS             
@@ -6122,7 +6122,7 @@
 
                                 *** print character A and colour X
 .,EA13 A8       TAY             copy the character
-.,EA14 A9 02    LDA #$02set the count to $02, usually $14 ??
+.,EA14 A9 02    LDA #$02        set the count to $02, usually $14 ??
 .,EA16 85 CD    STA $CD         save the cursor countdown
 .,EA18 20 24 EA JSR $EA24       calculate the pointer to colour RAM
 .,EA1B 98       TYA             get the character back
@@ -6467,7 +6467,7 @@
                                  2  1 = sprite to sprite collision interrupt
                                  1  1 = sprite to foreground collision interrupt
                                  0  1 = raster compare interrupt
-.:ECD3 00                       all vic IRQs disabeld
+.:ECD3 00                       all vic IRQs disabled
                                 IRQ enable
                                 bit function
                                 --- -------
@@ -6518,7 +6518,7 @@
                                 *** send a control character
 .,ED11 48       PHA             save device address
 .,ED12 24 94    BIT $94         test deferred character flag
-.,ED14 10 0A    BPL $ED20       if no defered character continue
+.,ED14 10 0A    BPL $ED20       if no deferred character continue
 .,ED16 38       SEC             else flag EOI
 .,ED17 66 A3    ROR $A3         rotate into EOI flag byte
 .,ED19 20 40 ED JSR $ED40       Tx byte on serial bus
@@ -6527,7 +6527,7 @@
 .,ED20 68       PLA             restore the device address
 
                                 *** defer a command
-.,ED21 85 95    STA $95         save as serial defered character
+.,ED21 85 95    STA $95         save as serial deferred character
 .,ED23 78       SEI             disable the interrupts
 .,ED24 20 97 EE JSR $EE97       set the serial data out high
 .,ED27 C9 3F    CMP #$3F        compare read byte with $3F
@@ -6599,7 +6599,7 @@
 .,ED8E C6 A5    DEC $A5         decrement the serial bus bit count
 .,ED90 D0 D4    BNE $ED66       loop if not all done
                                 now all eight bits have been sent it's up to the peripheral to signal the byte was
-                                received by pulling the serial data low. this should be done within one milisecond
+                                received by pulling the serial data low. this should be done within one millisecond
 .,ED92 A9 04    LDA #$04        wait for up to about 1ms
 .,ED94 8D 07 DC STA $DC07       save VIA 1 timer B high byte
 .,ED97 A9 19    LDA #$19        load timer B, timer B single shot, start timer B
@@ -6623,7 +6623,7 @@
 .,EDB7 90 4A    BCC $EE03       ATN high, delay, clock high then data high, branch always
 
                                 *** send secondary address after LISTEN
-.,EDB9 85 95    STA $95         save the defered Tx byte
+.,EDB9 85 95    STA $95         save the deferred Tx byte
 .,EDBB 20 36 ED JSR $ED36       set the serial clk/data, wait and Tx the byte
 
                                 *** set serial ATN high
@@ -6633,7 +6633,7 @@
 .,EDC6 60       RTS             
 
                                 *** send secondary address after TALK
-.,EDC7 85 95    STA $95         save the defered Tx byte
+.,EDC7 85 95    STA $95         save the deferred Tx byte
 .,EDC9 20 36 ED JSR $ED36       set the serial clk/data, wait and Tx the byte
 
                                 *** wait for the serial bus end after send
@@ -6649,14 +6649,14 @@
 
                                 *** output a byte to the serial bus
 .,EDDD 24 94    BIT $94         test the deferred character flag
-.,EDDF 30 05    BMI $EDE6       if there is a defered character go send it
+.,EDDF 30 05    BMI $EDE6       if there is a deferred character go send it
 .,EDE1 38       SEC             set carry
 .,EDE2 66 94    ROR $94         shift into the deferred character flag
 .,EDE4 D0 05    BNE $EDEB       save the byte and exit, branch always
 .,EDE6 48       PHA             save the byte
 .,EDE7 20 40 ED JSR $ED40       Tx byte on serial bus
 .,EDEA 68       PLA             restore the byte
-.,EDEB 85 95    STA $95         save the defered Tx byte
+.,EDEB 85 95    STA $95         save the deferred Tx byte
 .,EDED 18       CLC             flag ok
 .,EDEE 60       RTS             
 
@@ -6684,7 +6684,7 @@
 
                                 *** input a byte from the serial bus
 .,EE13 78       SEI             disable the interrupts
-.,EE14 A9 00    LDA #$00        set 0 bits to do, will flag EOI on timeour
+.,EE14 A9 00    LDA #$00        set 0 bits to do, will flag EOI on timeout
 .,EE16 85 A5    STA $A5         save the serial bus bit count
 .,EE18 20 85 EE JSR $EE85       set the serial clock out high
 .,EE1B 20 A9 EE JSR $EEA9       get the serial data status in Cb
@@ -6704,7 +6704,7 @@
                                 timer A timed out
 .,EE3E A5 A5    LDA $A5         get the serial bus bit count
 .,EE40 F0 05    BEQ $EE47       if not already EOI then go flag EOI
-.,EE42 A9 02    LDA #$02        else error $02, read timeour
+.,EE42 A9 02    LDA #$02        else error $02, read timeout
 .,EE44 4C B2 ED JMP $EDB2       set the serial status and exit
 .,EE47 20 A0 EE JSR $EEA0       set the serial data out low
 .,EE4A 20 85 EE JSR $EE85       set the serial clock out high
@@ -6832,7 +6832,7 @@
 
                                 *** setup next RS232 Tx byte
 .,EF06 AD 94 02 LDA $0294       read the 6551 pseudo command register
-.,EF09 4A       LSR             handshake bit inot Cb
+.,EF09 4A       LSR             handshake bit into Cb
 .,EF0A 90 07    BCC $EF13       if 3 line interface go ??
 .,EF0C 2C 01 DD BIT $DD01       test VIA 2 DRB, RS232 port
 .,EF0F 10 1D    BPL $EF2E       if DSR = 0 set DSR signal not present and exit
@@ -6967,7 +6967,7 @@
 .,EFF0 D0 20    BNE $F012       if RTS = 1 just exit
 .,EFF2 AD A1 02 LDA $02A1       get the RS-232 interrupt enable byte
 .,EFF5 29 02    AND #$02        mask 0000 00x0, timer B interrupt
-.,EFF7 D0 F9    BNE $EFF2       loop while the timer B interrupt is enebled
+.,EFF7 D0 F9    BNE $EFF2       loop while the timer B interrupt is enabled
 .,EFF9 2C 01 DD BIT $DD01       test VIA 2 DRB, RS232 port
 .,EFFC 70 FB    BVS $EFF9       loop while CTS high
 .,EFFE AD 01 DD LDA $DD01       read VIA 2 DRB, RS232 port
@@ -7036,7 +7036,7 @@
 .,F07A 4C 3B EF JMP $EF3B       set VIA 2 ICR from A and return
 .,F07D AD A1 02 LDA $02A1       get the RS-232 interrupt enable byte
 .,F080 29 12    AND #$12        mask 000x 00x0
-.,F082 F0 F3    BEQ $F077       if FLAG or timer B bits set go enable the FLAG inetrrupt
+.,F082 F0 F3    BEQ $F077       if FLAG or timer B bits set go enable the FLAG interrupt
 .,F084 18       CLC             flag ok
 .,F085 60       RTS             
 
@@ -7390,7 +7390,7 @@
 
                                 *** find file A
 .,F314 A6 98    LDX $98         get the open file count
-.,F316 CA       DEX             decrememnt the count to give the index
+.,F316 CA       DEX             decrement the count to give the index
 .,F317 30 15    BMI $F32E       if no files just exit
 .,F319 DD 59 02 CMP $0259,X     compare the logical file number with the table logical
                                 file number
@@ -8374,7 +8374,7 @@
 .,F9C3 A5 A3    LDA $A3         get EOI flag byte
 .,F9C5 10 30    BPL $F9F7       
 .,F9C7 30 BF    BMI $F988       
-.,F9C9 A2 A6    LDX #$A6        set timimg max byte
+.,F9C9 A2 A6    LDX #$A6        set timing max byte
 .,F9CB 20 E2 F8 JSR $F8E2       set timing
 .,F9CE A5 9B    LDA $9B         
 .,F9D0 D0 B9    BNE $F98B       
@@ -8406,7 +8406,7 @@
 .,FA02 30 C5    BMI $F9C9       
 .,FA04 46 D7    LSR $D7         
 .,FA06 66 BF    ROR $BF         parity count
-.,FA08 A2 DA    LDX #$DA        set timimg max byte
+.,FA08 A2 DA    LDX #$DA        set timing max byte
 .,FA0A 20 E2 F8 JSR $F8E2       set timing
 .,FA0D 4C BC FE JMP $FEBC       restore registers and exit interrupt
 .,FA10 A5 96    LDA $96         get cassette block synchronization number
@@ -8422,7 +8422,7 @@
 .,FA24 E5 B1    SBC $B1         subtract tape timing constant max byte
 .,FA26 65 B0    ADC $B0         add tape timing constant min byte
 .,FA28 0A       ASL             
-.,FA29 AA       TAX             copy timimg high byte
+.,FA29 AA       TAX             copy timing high byte
 .,FA2A 20 E2 F8 JSR $F8E2       set timing
 .,FA2D E6 9C    INC $9C         
 .,FA2F A5 B4    LDA $B4         
@@ -8452,7 +8452,7 @@
                                 *** # store character
 .,FA60 20 97 FB JSR $FB97       new tape byte setup
 .,FA63 85 9C    STA $9C         clear byte received flag
-.,FA65 A2 DA    LDX #$DA        set timimg max byte
+.,FA65 A2 DA    LDX #$DA        set timing max byte
 .,FA67 20 E2 F8 JSR $F8E2       set timing
 .,FA6A A5 BE    LDA $BE         get copies count
 .,FA6C F0 02    BEQ $FA70       
@@ -8653,7 +8653,7 @@
                                 stops the tape
 .,FBCD A5 A8    LDA $A8         get start bit first cycle done flag
 .,FBCF D0 12    BNE $FBE3       if first cycle done go do rest of byte
-                                each byte sent starts with two half cycles of $0110 ststem clocks and the whole block
+                                each byte sent starts with two half cycles of $0110 system clocks and the whole block
                                 ends with two more such half cycles
 .,FBD1 A9 10    LDA #$10        set first start cycle time constant low byte
 .,FBD3 A2 01    LDX #$01        set first start cycle time constant high byte
@@ -8670,7 +8670,7 @@
                                 so the routine drops straight through to here
 .,FBE3 A5 A9    LDA $A9         get start bit check flag
 .,FBE5 D0 09    BNE $FBF0       if the start bit is complete go send the byte bits
-                                after the two half cycles of $0110 ststem clocks the start bit is completed with two
+                                after the two half cycles of $0110 system clocks the start bit is completed with two
                                 half cycles of $00B0 system clocks. this is the same as the first part of a 1 bit
 .,FBE7 20 AD FB JSR $FBAD       set time constant for bit = 1 and toggle tape
 .,FBEA D0 1D    BNE $FC09       if first half cycle go restore registers and exit
@@ -8858,7 +8858,7 @@
                                 *** scan for autostart ROM at $8000, returns Zb=1 if ROM found
 .,FD02 A2 05    LDX #$05        five characters to test
 .,FD04 BD 0F FD LDA $FD0F,X     get test character
-.,FD07 DD 03 80 CMP $8003,X     compare wiith byte in ROM space
+.,FD07 DD 03 80 CMP $8003,X     compare with byte in ROM space
 .,FD0A D0 03    BNE $FD0F       exit if no match
 .,FD0C CA       DEX             decrement index
 .,FD0D D0 F5    BNE $FD04       loop if not all done
@@ -8992,7 +8992,7 @@
 .,FDC4 8E 18 D4 STX $D418       clear the volume and filter select register
 .,FDC7 CA       DEX             set X = $FF
 .,FDC8 8E 02 DC STX $DC02       save VIA 1 DDRA, keyboard column
-.,FDCB A9 07    LDA #$07        DATA out high, CLK out high, ATN out high, RE232 Tx DATA
+.,FDCB A9 07    LDA #$07        DATA out high, CLK out high, ATN out high, RS232 Tx DATA
                                 high, video address 15 = 1, video address 14 = 1
 .,FDCD 8D 00 DD STA $DD00       save VIA 2 DRA, serial port and video address
 .,FDD0 A9 3F    LDA #$3F        set serial DATA input, serial CLK input
@@ -9610,6 +9610,6 @@
 .:FFF6 52 52 42 59              RRBY
 
                                 *** hardware vectors
-.:FFFA 43 FE                    NMI Vektor
-.:FFFC E2 FC                    RESET Vektor
-.:FFFE 48 FF                    IRQ Vektor
+.:FFFA 43 FE                    NMI Vector
+.:FFFC E2 FC                    RESET Vector
+.:FFFE 48 FF                    IRQ Vector

--- a/src/c64disasm/c64disasm_mm.txt
+++ b/src/c64disasm/c64disasm_mm.txt
@@ -275,10 +275,10 @@
 .:A342 5A A2                    0E illegal quantity
 .:A344 6A A2                    0F overflow
 .:A346 72 A2                    10 out of memory
-.:A348 7F A2                    11 undef'd statment
+.:A348 7F A2                    11 undef'd statement
 .:A34A 90 A2                    12 bad subscript
 .:A34C 9D A2                    13 redim'd array
-.:A34E AA A2                    14 devision by zero
+.:A34E AA A2                    14 division by zero
 .:A350 BA A2                    15 illegal direct
 .:A352 C8 A2                    16 type mismatch
 .:A354 D5 A2                    17 string too long
@@ -1321,7 +1321,7 @@
 .,AA7D 91 49    STA ($49),Y     
 .,AA7F 60       RTS             
 
-                                *** PRINT# comand
+                                *** PRINT# command
 .,AA80 20 86 AA JSR $AA86       
 .,AA83 4C B5 AB JMP $ABB5       
 
@@ -1646,7 +1646,7 @@
 .,ACF8 4C 1E AB JMP $AB1E       
 .,ACFB 60       RTS             
 
-                                *** messages used dring READ
+                                *** messages used during READ
 .:ACFC 3F 45 58 54 52 41 20 49  ?EXTRA IGNORED
 .:AD04 47 4E 4F 52 45 44 0D 00  
 .:AD0C 3F 52 45 44 4F 20 46 52  ?REDO FROM START
@@ -1927,7 +1927,7 @@
 .,AF08 A2 0B    LDX #$0B        error number
 .,AF0A 4C 37 A4 JMP $A437       
 
-                                *** recursive geet value
+                                *** recursive get value
 .,AF0D A0 15    LDY #$15        
 .,AF0F 68       PLA             
 .,AF10 68       PLA             
@@ -4327,7 +4327,7 @@
 .,BFBC 85 66    STA $66         
 .,BFBE 60       RTS             
 
-                                *** floating point constands for EXP
+                                *** floating point constants for EXP
                                 1/LOG(2)
 .:BFBF 81 38 AA 3B 29           
 
@@ -4835,7 +4835,7 @@
 .,E3C8 A0 B2    LDY #$B2        high B248
 .,E3CA 8D 11 03 STA $0311       
 .,E3CD 8C 12 03 STY $0312       
-.,E3D0 A9 91    LDA #$91        lowh B391
+.,E3D0 A9 91    LDA #$91        low  B391
 .,E3D2 A0 B3    LDY #$B3        high B391
 .,E3D4 85 05    STA $05         
 .,E3D6 84 06    STY $06         
@@ -4950,7 +4950,7 @@
 .,E4DD 91 F3    STA ($F3),Y     
 .,E4DF 60       RTS             
 
-                                *** pause after finding a file on casette
+                                *** pause after finding a file on cassette
 .,E4E0 69 02    ADC #$02        
 .,E4E2 A4 91    LDY $91         
 .,E4E4 C8       INY             
@@ -5032,7 +5032,7 @@
 .,E568 84 D3    STY $D3         
 .,E56A 84 D6    STY $D6         
 
-                                *** set address of curent screen line
+                                *** set address of current screen line
 .,E56C A6 D6    LDX $D6         
 .,E56E A5 D3    LDA $D3         
 .,E570 B4 D9    LDY $D9,X       
@@ -5686,7 +5686,7 @@
 
                                 *** set cursor flash timing and colour memory addresses
 .,EA13 A8       TAY             
-.,EA14 A9 02    LDA #$02set the 
+.,EA14 A9 02    LDA #$02
 .,EA16 85 CD    STA $CD         
 .,EA18 20 24 EA JSR $EA24       
 .,EA1B 98       TYA             
@@ -5698,7 +5698,7 @@
 .,EA21 91 F3    STA ($F3),Y     
 .,EA23 60       RTS             
 
-                                *** set colour memory adress parallel to screen
+                                *** set colour memory address parallel to screen
 .,EA24 A5 D1    LDA $D1         
 .,EA26 85 F3    STA $F3         
 .,EA28 A5 D2    LDA $D2         
@@ -5729,7 +5729,7 @@
 .,EA5A A5 CE    LDA $CE         
 .,EA5C 49 80    EOR #$80        
 .,EA5E 20 1C EA JSR $EA1C       display cursor
-.,EA61 A5 01    LDA $01         checl cassette sense
+.,EA61 A5 01    LDA $01         check cassette sense
 .,EA63 29 10    AND #$10        
 .,EA65 F0 0A    BEQ $EA71       
 .,EA67 A0 00    LDY #$00        
@@ -6441,7 +6441,7 @@
 .,F049 8D 0E DD STA $DD0E       
 .,F04C 60       RTS             
 
-                                *** initalise RS-232 input
+                                *** initialise RS-232 input
 .,F04D 85 99    STA $99         
 .,F04F AD 94 02 LDA $0294       
 .,F052 4A       LSR             
@@ -6485,7 +6485,7 @@
 .,F0A1 A9 00    LDA #$00        
 .,F0A3 60       RTS             
 
-                                *** protect serial/casette routine from RS-232 NMI's
+                                *** protect serial/cassette routine from RS-232 NMI's
 .,F0A4 48       PHA             
 .,F0A5 AD A1 02 LDA $02A1       
 .,F0A8 F0 11    BEQ $F0BB       
@@ -7935,7 +7935,7 @@
 .,FB94 85 AC    STA $AC         
 .,FB96 60       RTS             
 
-                                *** initalise cassette read/write variables
+                                *** initialise cassette read/write variables
 .,FB97 A9 08    LDA #$08        
 .,FB99 85 A3    STA $A3         
 .,FB9B A9 00    LDA #$00        
@@ -7946,7 +7946,7 @@
 .,FBA5 60       RTS             
 
                                 *** schedule CIA1 timer B and
-                                invert casette write line
+                                invert cassette write line
 .,FBA6 A5 BD    LDA $BD         
 .,FBA8 4A       LSR             
 .,FBA9 A9 60    LDA #$60        
@@ -8177,7 +8177,7 @@
 .:FD4C A5 F4                    load ram
 .:FD4E ED F5                    save ram
 
-                                *** initalise memory pointers
+                                *** initialise memory pointers
 .,FD50 A9 00    LDA #$00        
 .,FD52 A8       TAY             
 .,FD53 99 02 00 STA $0002,Y     
@@ -8225,7 +8225,7 @@
 .:FD9F 31 EA                    standard IRQ
 .:FDA1 2C F9                    cassette read
 
-                                *** initaliase I/O devices
+                                *** initialise I/O devices
 .,FDA3 A9 7F    LDA #$7F        
 .,FDA5 8D 0D DC STA $DC0D       
 .,FDA8 8D 0D DD STA $DD0D       
@@ -8250,7 +8250,7 @@
 .,FDD9 A9 2F    LDA #$2F        
 .,FDDB 85 00    STA $00         
 
-                                *** initalise TAL1/TAH1 fpr 1/60 of a second
+                                *** initialise TAL1/TAH1 for 1/60 of a second
 .,FDDD AD A6 02 LDA $02A6       
 .,FDE0 F0 0A    BEQ $FDEC       
 .,FDE2 A9 25    LDA #$25        
@@ -8263,13 +8263,13 @@
 .,FDF3 8D 05 DC STA $DC05       
 .,FDF6 4C 6E FF JMP $FF6E       
 
-                                *** initalise file name parameters
+                                *** initialise file name parameters
 .,FDF9 85 B7    STA $B7         
 .,FDFB 86 BB    STX $BB         
 .,FDFD 84 BC    STY $BC         
 .,FDFF 60       RTS             
 
-                                *** inatalise file parameters
+                                *** initialise file parameters
 .,FE00 85 B8    STA $B8         
 .,FE02 86 BA    STX $BA         
 .,FE04 84 B9    STY $B9         
@@ -8297,7 +8297,7 @@
 .,FE1E 85 90    STA $90         
 .,FE20 60       RTS             
 
-                                *** set timeout on serail bus
+                                *** set timeout on serial bus
 .,FE21 8D 85 02 STA $0285       
 .,FE24 60       RTS             
 
@@ -8465,7 +8465,7 @@
 .,FF55 6C 16 03 JMP ($0316)     normally FE66
 .,FF58 6C 14 03 JMP ($0314)     normally EA31
 
-                                *** addition to I/O device initalisation
+                                *** addition to I/O device initialisation
 .,FF5B 20 18 E5 JSR $E518       
 .,FF5E AD 12 D0 LDA $D012       
 .,FF61 D0 FB    BNE $FF5E       
@@ -8485,9 +8485,9 @@
 .:FF80 03                       kernal version number
 
                                 *** kernal vectors
-.,FF81 4C 5B FF JMP $FF5B       initalise screen and keyboard
-.,FF84 4C A3 FD JMP $FDA3       initalise I/O devices
-.,FF87 4C 50 FD JMP $FD50       initalise memory pointers
+.,FF81 4C 5B FF JMP $FF5B       initialise screen and keyboard
+.,FF84 4C A3 FD JMP $FDA3       initialise I/O devices
+.,FF87 4C 50 FD JMP $FD50       initialise memory pointers
 .,FF8A 4C 15 FD JMP $FD15       restore I/O vectors
 .,FF8D 4C 1A FD JMP $FD1A       set I/O vectors from XY
 .,FF90 4C 18 FE JMP $FE18       control kernal messages
@@ -8496,7 +8496,7 @@
 .,FF99 4C 25 FE JMP $FE25       read/set top of memory
 .,FF9C 4C 34 FE JMP $FE34       read/set bottom of memory
 .,FF9F 4C 87 EA JMP $EA87       scan keyboard
-.,FFA2 4C 21 FE JMP $FE21       set timout for serial bus
+.,FFA2 4C 21 FE JMP $FE21       set timeout for serial bus
 .,FFA5 4C 13 EE JMP $EE13       input on serial bus
 .,FFA8 4C DD ED JMP $EDDD       output byte on serial bus
 .,FFAB 4C EF ED JMP $EDEF       send untalk on serial bus

--- a/src/c64disasm/c64disasm_mn.txt
+++ b/src/c64disasm/c64disasm_mn.txt
@@ -110,8 +110,8 @@
                                 This routine is sets parameters for save, and calls the
                                 save routine. The start and end addresses are obtained
                                 from TXTTAB and VARTAB. Finally, a test is made if any
-                                errors ocured.
-.,E156 20 D4 E1 JSR $E1D4       get SAVE paramerters from text
+                                errors occurred.
+.,E156 20 D4 E1 JSR $E1D4       get SAVE parameters from text
 .,E159 A6 2D    LDX $2D         VARTAB, start of variables
 .,E15B A4 2E    LDY $2E
 .,E15D A9 2B    LDA #$2B        <TXTTAB, start of BASIC text
@@ -125,7 +125,7 @@
                                 setting VERCK accordingly. The LOAD/VERIFY parameters,
                                 filename, device etc. are obtained from text before the
                                 KERNAL routine LOAD is called. A test is made for I/O
-                                errors. At this point, the two functios are distiguished.
+                                errors. At this point, the two functions are distinguished.
                                 VERIFY reads the the status word and prints the message OK
                                 or ?VERIFY error depending on the result of the test. LOAD
                                 reads the I/O status word for a possible ?LOAD error, then
@@ -173,7 +173,7 @@
 .,E1BB 4C 77 A6 JMP $A677       do RESTORE and reset OLDTXT
 
                                 *** OPENT: PERFORM OPEN
-                                This routine extracts paramerters from text and performs
+                                This routine extracts parameters from text and performs
                                 the OPEN routine in KERNAL. A test is made for I/O errors.
 .,E1BE 20 19 E2 JSR $E219       get parameters from text
 .,E1C1 20 C0 FF JSR $FFC0       execute OPEN
@@ -237,7 +237,7 @@
                                 *** CMMERR: CHECK FOR COMMA
                                 This routine confirms that the next character in the text
                                 is a comma. It also test that the comma is not immediately
-                                ollowed by a terminator. If so, exit and do SYNTAX error.
+                                followed by a terminator. If so, exit and do SYNTAX error.
 .,E20E 20 FD AE JSR $AEFD       confirm comma
 .,E211 20 79 00 JSR $0079       get CHRGOT
 .,E214 D0 F7    BNE $E20D       else than null
@@ -249,7 +249,7 @@
                                 the default filename is set to null, and the device number
                                 to #1. The logical filenumber is compulsory, and is
                                 obtained from text and placed in <FORPNT. The other
-                                parameters are optinal and are obtained if present. The
+                                parameters are optional and are obtained if present. The
                                 device number is stored in >FORPNT. The parameters are set
                                 via the KERNAL routines SETNAM and SETLFS.
 .,E219 A9 00    LDA #$00        default filename is null
@@ -266,7 +266,7 @@
 .,E234 86 4A    STX $4A         store in >FORPNT
 .,E236 A0 00    LDY #$00        secondary address = #0
 .,E238 A5 49    LDA $49         logical file number from temp store
-.,E23A E0 03    CPX #$03        test if serial devce
+.,E23A E0 03    CPX #$03        test if serial device
 .,E23C 90 01    BCC $E23F       nope
 .,E23E 88       DEY             if serial, set secondary address to $ff
 .,E23F 20 BA FF JSR $FFBA       SETLFS
@@ -286,7 +286,7 @@
 .,E261 4C BD FF JMP $FFBD       SETNAM and exit
 
                                 *** COS: PERFORM COS
-                                This routine manipulates the input COS to be calcuated
+                                This routine manipulates the input COS to be calculated
                                 with SIN. COS(X) = SIN(X+pi/2), where  X is in radians. We
                                 use it as Fac#1=SIN(fac#1+pi/2), ie pi/2 is added to fac#1
                                 and the following SIN is performed.
@@ -391,7 +391,7 @@
 
 
                                 *** ATNCON: TABLE OF ATN CONSTANTS
-                                The table holds a 1 byte counter and the folloeing 5 byte
+                                The table holds a 1 byte counter and the following 5 byte
                                 flpt constants.
 .:E33E 0B                       ; 13 (one byte counter for ATN series)
 .:E33F 76 B3 83 BD D3           ; -0.000684793912 (ATN constant 1)
@@ -518,7 +518,7 @@
 
                                 *** INITMS: OUTPUT POWER-UP MESSAGE
                                 This routine outputs the startup message. It then
-                                calcuates the number of BASIC bytes free by subatracting
+                                calculates the number of BASIC bytes free by subtracting
                                 the TXTTAB from MEMSIZ, and outputs this number. The
                                 routine exits via NEW.
 .,E422 A5 2B    LDA $2B         read TXTTAB, start of BASIC
@@ -528,8 +528,8 @@
 .,E42B A0 E4    LDY #$E4
 .,E42D 20 1E AB JSR $AB1E       output (A/Y)
 .,E430 A5 37    LDA $37         MEMSIZ, highest address in BASIC
-.,E432 38       SEC             prepare for substract
-.,E433 E5 2B    SBC $2B         substract TXTTAB
+.,E432 38       SEC             prepare for subtract
+.,E433 E5 2B    SBC $2B         subtract TXTTAB
 .,E435 AA       TAX             move to (X)
 .,E436 A5 38    LDA $38         and highbyte
 .,E438 E5 2C    SBC $2C
@@ -540,7 +540,7 @@
 .,E444 4C 44 A6 JMP $A644       perform NEW
 
                                 *** VECTORS
-                                This table contains jump vectors that are transfered to
+                                This table contains jump vectors that are transferred to
                                 $0300-$030b.
 .:E447 8B E3                    IERROR VEC, print basic error message ($e38b)
 .:E449 83 A4                    IMAIN VECTOR, basic warm start ($a483)
@@ -561,7 +561,7 @@
                                 *** WORDS: POWER UP MESSAGE
                                 This is the power up message displayed on the screen when
                                 the 'Commie' is switched on or reset. The strings are
-                                seperated by a zero byte.
+                                separated by a zero byte.
 .:E45F 00 20 42 41 53 49 43 20  basic bytes free
 .:E467 42 59 54 45 53 20 46 52
 .:E46F 45 45 0D 00 93 0D 20 20
@@ -576,7 +576,7 @@
 .:E4AC 5C
 
                                 *** PATCH FOR BASIC CHKOUT CALL
-                                This is a short patch added for the KERNAL ROM to preserv
+                                This is a short patch added for the KERNAL ROM to preserve
                                 (A) when there was no error returned from BASIC calling
                                 the CHKOUT routine. This corrects a bug in the early
                                 versions of PRINT# and CMD.
@@ -622,9 +622,9 @@
 .,E4EB 60       RTS
 
                                 *** RS232 TIMING TABLE - PAL
-                                Timingtable for RS232 NMI for use with PAL machines. This
+                                Timing table for RS232 NMI for use with PAL machines. This
                                 table contains the prescaler values for setting up the
-                                RS232 baudrates. The table containe 10 entries which
+                                RS232 baudrates. The table contains 10 entries which
                                 corresponds to one of the fixed RS232 rates, starting with
                                 lowest (50 baud) and finishing with the highest (2400
                                 baud). Since the clock frequency is different between NTSC
@@ -674,7 +674,7 @@
                                 This routine is part of the KERNAL CINT init routine. I/O
                                 default values are set, <shift+cbm> keys are disabled, and
                                 cursor is switched off. The vector to the keyboard table
-                                is set up, and the length of the keyboardbuffer is set to
+                                is set up, and the length of the keyboard buffer is set to
                                 10 characters. The cursor color is set to lightblue, and
                                 the key-repeat parameters are set up.
 .,E518 20 A0 E5 JSR $E5A0       set I/O defaults
@@ -688,7 +688,7 @@
 .,E52C A9 0A    LDA #$0A        set max number of character is keyboard buffer to 10
 .,E52E 8D 89 02 STA $0289       XMAX
 .,E531 8D 8C 02 STA $028C       How many 1/60 of a second to wait before key is repeated.
-                                Used togeather with $028b
+                                Used together with $028b
 .,E534 A9 0E    LDA #$0E        set character colour to light blue
 .,E536 8D 86 02 STA $0286       COLOR
 .,E539 A9 04    LDA #$04        How many $028c before a new entry is
@@ -738,7 +738,7 @@
 .,E56C A6 D6    LDX $D6         read TBLX
 .,E56E A5 D3    LDA $D3         read PNTR
 .,E570 B4 D9    LDY $D9,X       read value from screen line link table, LDTB1
-.,E572 30 08    BMI $E57C       heavy calcuations??? jump when ready
+.,E572 30 08    BMI $E57C       heavy calculations??? jump when ready
 .,E574 18       CLC
 .,E575 69 28    ADC #$28
 .,E577 85 D3    STA $D3         PNTR
@@ -755,7 +755,7 @@
 .,E58A 10 F6    BPL $E582
 .,E58C 85 D5    STA $D5         store in LMNX, physical screen line length
 .,E58E 4C 24 EA JMP $EA24       sync color pointer
-.,E591 E4 C9    CPX $C9         read LXSP, chech cursor at start of input
+.,E591 E4 C9    CPX $C9         read LXSP, check cursor at start of input
 .,E593 F0 03    BEQ $E598
 .,E595 4C ED E6 JMP $E6ED       retreat cursor
 .,E598 60       RTS
@@ -781,7 +781,7 @@
 .,E5B3 60       RTS
 
                                 *** LP2: GET CHARACTER FROM KEYBOARD BUFFER
-                                It is assumed that there is at leaset one character in the
+                                It is assumed that there is at least one character in the
                                 keyboard buffer. This character is obtained and the rest
                                 of the queue is moved up one by one to overwrite it. On
                                 exit, the character is in (A).
@@ -827,7 +827,7 @@
 .,E5F6 9D 76 02 STA $0276,X     store in keyboard buffer
 .,E5F9 CA       DEX
 .,E5FA D0 F7    BNE $E5F3       all nine characters
-.,E5FC F0 CF    BEQ $E5CD       allways jump
+.,E5FC F0 CF    BEQ $E5CD       always jump
 .,E5FE C9 0D    CMP #$0D        carriage return pressed?
 .,E600 D0 C8    BNE $E5CA       nope, go to start
 .,E602 A4 D5    LDY $D5         get LNMX, screen line length
@@ -842,8 +842,8 @@
 .,E612 A0 00    LDY #$00
 .,E614 8C 92 02 STY $0292       AUTODN
 .,E617 84 D3    STY $D3         PNTR, cursor column
-.,E619 84 D4    STY $D4         QTSW, reset quoute mode
-.,E61B A5 C9    LDA $C9         LXSP, corsor X/Y position
+.,E619 84 D4    STY $D4         QTSW, reset quotes mode
+.,E61B A5 C9    LDA $C9         LXSP, cursor X/Y position
 .,E61D 30 1B    BMI $E63A
 .,E61F A6 D6    LDX $D6         TBLX, cursor line number
 .,E621 20 ED E6 JSR $E6ED       retreat cursor
@@ -924,8 +924,8 @@
                                 The RVS flag is tested to see if reversed characters are
                                 to be printed. If insert mode is on, the insert counter is
                                 decremented by one. When in insert mode, all characters
-                                will be displayd, ie. DEL RVS etc. The character colour is
-                                placed in (X) and the character is printed to the scrren
+                                will be displayed, ie. DEL RVS etc. The character colour is
+                                placed in (X) and the character is printed to the screen
                                 and the cursor advanced.
 .,E691 09 40    ORA #$40
 .,E693 A6 C7    LDX $C7         test RVS, flag for reversed characters
@@ -1011,7 +1011,7 @@
 .,E705 86 D3    STX $D3         set PNTR to zero as well
 .,E707 68       PLA
 .,E708 68       PLA
-.,E709 D0 9D    BNE $E6A8       allways jump
+.,E709 D0 9D    BNE $E6A8       always jump
 .,E70B CA       DEX             decrement TBLX
 .,E70C 86 D6    STX $D6         and store
 .,E70E 20 6C E5 JSR $E56C       set screen pointers
@@ -1026,7 +1026,7 @@
                                 automatically updated and scrolling occurs if necessary.
                                 On entry, (A) must hold the character to be output. On
                                 entry all registers are stored on the stack. For
-                                convinience, the routine is slpit into sections showing
+                                convenience, the routine is split into sections showing
                                 the processing of both shifted and unshifted character.
 .,E716 48       PHA             store (A), (X) and (Y) on stack
 .,E717 85 D7    STA $D7         temp store
@@ -1062,7 +1062,7 @@
 .,E742 4C 93 E6 JMP $E693       setup screen print
 .,E745 A6 D8    LDX $D8         INSRT, insert mode flag
 .,E747 F0 03    BEQ $E74C       mode not set
-.,E749 4C 97 E6 JMP $E697       output reversed charcter
+.,E749 4C 97 E6 JMP $E697       output reversed character
 .,E74C C9 14    CMP #$14        <DEL>?
 .,E74E D0 2E    BNE $E77E       nope
 .,E750 98       TYA             (Y) holds cursor column
@@ -1072,7 +1072,7 @@
 .,E759 20 A1 E8 JSR $E8A1       check line decrement
 .,E75C 88       DEY             decrement cursor column
 .,E75D 84 D3    STY $D3         and store in PNTR
-.,E75F 20 24 EA JSR $EA24       syncronise colour pointer
+.,E75F 20 24 EA JSR $EA24       synchronise colour pointer
 .,E762 C8       INY             copy character at cursor position (Y+1) to (Y)
 .,E763 B1 D1    LDA ($D1),Y     read character
 .,E765 88       DEY
@@ -1088,7 +1088,7 @@
 .,E775 91 D1    STA ($D1),Y     store <SPACE> at end of line
 .,E777 AD 86 02 LDA $0286       COLOR, current character colour
 .,E77A 91 F3    STA ($F3),Y     store colour at end of line
-.,E77C 10 4D    BPL $E7CB       allways jump
+.,E77C 10 4D    BPL $E7CB       always jump
 .,E77E A6 D4    LDX $D4         QTSW, editor in quotes mode
 .,E780 F0 03    BEQ $E785       no
 .,E782 4C 97 E6 JMP $E697       output reversed character
@@ -1132,7 +1132,7 @@
 .,E7D1 4C 44 EC JMP $EC44       do graphics/text control
 
                                 SHIFTED CHARACTERS. These are dealt with in the following
-                                order: Shifted ordinart ASCII and PET graphics characters,
+                                order: Shifted ordinary ASCII and PET graphics characters,
                                 <shift RETURN>, <INST>, <CRSR UP>, <RVS OFF>, <CRSR LEFT>,
                                 <CLR>. If either insert mode is on, or quotes are open,
                                 then the control character is not processed but reversed
@@ -1161,7 +1161,7 @@
 .,E800 F0 24    BEQ $E826       end of logical line, can not insert
 .,E802 20 65 E9 JSR $E965       open space on line
 .,E805 A4 D5    LDY $D5         LNMX
-.,E807 20 24 EA JSR $EA24       syncronise colour pointer
+.,E807 20 24 EA JSR $EA24       synchronise colour pointer
 .,E80A 88       DEY             prepare for move
 .,E80B B1 D1    LDA ($D1),Y     read character at pos (Y)
 .,E80D C8       INY
@@ -1189,7 +1189,7 @@
 .,E838 F0 37    BEQ $E871       at topline, do nothing
 .,E83A C6 D6    DEC $D6         else decrement TBLX
 .,E83C A5 D3    LDA $D3         PNTR
-.,E83E 38       SEC             prepare for substract
+.,E83E 38       SEC             prepare for subtract
 .,E83F E9 28    SBC #$28        back 40 columns for double line
 .,E841 90 04    BCC $E847       skip
 .,E843 85 D3    STA $D3         store PNTR
@@ -1235,7 +1235,7 @@
 .,E88E 4C 6C E5 JMP $E56C       set screen pointers
 
                                 *** OUTPUT <CARRIAGE RETURN>
-                                All editor modes are swithed off and the cursor placed at
+                                All editor modes are switched off and the cursor placed at
                                 the start of the next line.
 .,E891 A2 00    LDX #$00
 .,E893 86 D8    STX $D8         INSRT, disable insert mode
@@ -1284,7 +1284,7 @@
                                 *** SET COLOUR CODE
                                 This routine is called by the output to screen routine.
                                 The Commodore ASCII code in (A) is compared with the ASCII
-                                colout code table. If a match is found, then the table
+                                colour code table. If a match is found, then the table
                                 offset (and hence the colour value) is stored in COLOR.
 .,E8CB A2 0F    LDX #$0F        16 values to be tested
 .,E8CD DD DA E8 CMP $E8DA,X     compare with colour code table
@@ -1319,7 +1319,7 @@
 
                                 *** SCROLL SCREEN
                                 This routine scrolls the screen down by one line. If the
-                                top two lines are linked togeather, then the scroll down
+                                top two lines are linked together, then the scroll down
                                 is repeated. The screen line link pointers are updated,
                                 each screen line is cleared and the line below is moved
                                 up. The keyboard is directly read from CIA#1, and the
@@ -1347,7 +1347,7 @@
 .,E911 30 EC    BMI $E8FF
 .,E913 20 FF E9 JSR $E9FF       clear a screen line
 .,E916 A2 00    LDX #$00
-.,E918 B5 D9    LDA $D9,X       calcuate new screen line link table
+.,E918 B5 D9    LDA $D9,X       calculate new screen line link table
 .,E91A 29 7F    AND #$7F        clear bit7
 .,E91C B4 DA    LDY $DA,X
 .,E91E 10 02    BPL $E922
@@ -1463,8 +1463,8 @@
 .,E9DF 60       RTS
 
                                 *** SYNCHRONISE COLOUR TRANSFER
-                                This routine setd up a temporary pointer in EAL to the
-                                colour RAM address that corresponts to the temporary
+                                This routine sets up a temporary pointer in EAL to the
+                                colour RAM address that corresponds to the temporary
                                 screen address held in EAL.
 .,E9E0 20 24 EA JSR $EA24       synchronise colour pointer
 .,E9E3 A5 AC    LDA $AC         SAL, pointer for screen scroll
@@ -1489,7 +1489,7 @@
 
                                 *** CLEAR SCREEN LINE
                                 The start of line is set and the screen line is cleared by
-                                filloing it with ASCII spaces. The corresponding line of
+                                filling it with ASCII spaces. The corresponding line of
                                 colour RAM is also cleared to the value held in COLOR.
 .,E9FF A0 27    LDY #$27
 .,EA01 20 F0 E9 JSR $E9F0       set start of line
@@ -1509,20 +1509,20 @@
                                 colour in (X) is stored at the equivalent point in the
                                 colour RAM.
 .,EA13 A8       TAY             put print character in (Y)
-.,EA14 A9 02    LDA #$02set the
-.,EA16 85 CD    STA $CD         store in BLNCT, timer to toggle cursor
+.,EA14 A9 02    LDA #$02
+.,EA16 85 CD    STA $CD         store initial value in BLNCT, timer to toggle cursor
 .,EA18 20 24 EA JSR $EA24       synchronise colour pointer
 .,EA1B 98       TYA             print character back to (A)
 .,EA1C A4 D3    LDY $D3         PNTR, cursor column on line
 .,EA1E 91 D1    STA ($D1),Y     store character on screen
 .,EA20 8A       TXA
-.,EA21 91 F3    STA ($F3),Y     stor character colour
+.,EA21 91 F3    STA ($F3),Y     store character colour
 .,EA23 60       RTS
 
                                 *** SYNCHRONISE COLOUR POINTER
                                 The pointer to the colour RAM is set up according to the
                                 current screen line address. This is done by reading the
-                                current screen line address and modefying it to colour RAM
+                                current screen line address and modifying it to colour RAM
                                 pointers and write it to USER at $f3/$f4
 .,EA24 A5 D1    LDA $D1         copy screen line low byte
 .,EA26 85 F3    STA $F3         to colour RAM low byte
@@ -1638,12 +1638,12 @@
 .,EADC 68       PLA             clean up
 
                                 *** PROCESS KEY IMAGE
-                                This routine decodes the pressed key, and calcuates its
+                                This routine decodes the pressed key, and calculates its
                                 ASCII value, by use of the four tables. If the pressed key
                                 is the same key as in the former interrupt, then the key-
                                 repeat-section is entered. The routine tests the RPTFLG if
                                 he key shall repeat. The new key is stored in the keyboard
-                                buffer, and all pointers are uppdated.
+                                buffer, and all pointers are updated.
 .,EADD 6C 8F 02 JMP ($028F)     jump through KEYLOG vector, points to $eae0
 .,EAE0 A4 CB    LDY $CB         SFDX, number of the key we pressed
 .,EAE2 B1 F5    LDA ($F5),Y     get ASCII value from decode table
@@ -1671,7 +1671,7 @@
 .,EB10 F0 05    BEQ $EB17       skip
 .,EB12 CE 8C 02 DEC $028C       decrement DELAY
 .,EB15 D0 2B    BNE $EB42       end
-.,EB17 CE 8B 02 DEC $028B       decremant KOUNT, repeat speed counter
+.,EB17 CE 8B 02 DEC $028B       decrement KOUNT, repeat speed counter
 .,EB1A D0 26    BNE $EB42       end
 .,EB1C A0 04    LDY #$04
 .,EB1E 8C 8B 02 STY $028B       init KOUNT
@@ -1725,11 +1725,11 @@
 .:EB7F 78 EC                    vector to ctrl keyboard, $ec78
 
                                 *** KEYBOARD 1 - UNSHIFTED
-                                This is the first of four keybboard decode tables. The
+                                This is the first of four keyboard decode tables. The
                                 ASCII code for the key pressed is at the intersection of
                                 the row (written to $dc00) and the column (read from
                                 $dc01). The matrix values are shown below. Note that left
-                                and right shift keys are seperated.
+                                and right shift keys are separated.
 .:EB81 14 0D 1D 88 85 86 87 11
 .:EB89 33 57 41 34 5A 53 45 01
 .:EB91 35 52 44 36 43 46 54 58
@@ -1758,7 +1758,7 @@
                                 *** KEYBOARD 3 - COMMODORE
                                 This is the third of four keyboard decode tables. The
                                 ASCII code for the key pressed is at the intersection of
-                                the ro (written to $dc00) and hte column (read from
+                                the ro (written to $dc00) and the column (read from
                                 $dc01). The matrix values are shown below.
 .:EC03 94 8D 9D 8C 89 8A 8B 91
 .:EC0B 96 B3 B0 97 AD AE B1 01
@@ -1779,7 +1779,7 @@
 .,EC46 D0 07    BNE $EC4F       nope
 .,EC48 AD 18 D0 LDA $D018       VIC memory control register
 .,EC4B 09 02    ORA #$02        set bit1
-.,EC4D D0 09    BNE $EC58       allways branch
+.,EC4D D0 09    BNE $EC58       always branch
 .,EC4F C9 8E    CMP #$8E        <switch to upper case>
 .,EC51 D0 0B    BNE $EC5E       nope
 .,EC53 AD 18 D0 LDA $D018       VIC memory control register
@@ -1790,7 +1790,7 @@
 .,EC60 D0 07    BNE $EC69       nope
 .,EC62 A9 80    LDA #$80
 .,EC64 0D 91 02 ORA $0291       disable MODE
-.,EC67 30 09    BMI $EC72       allways jump
+.,EC67 30 09    BMI $EC72       always jump
 .,EC69 C9 09    CMP #$09        <enable <shift-CBM>>
 .,EC6B D0 EE    BNE $EC5B       nope, exit
 .,EC6D A9 7F    LDA #$7F
@@ -1807,7 +1807,7 @@
                                 <ctrl H> - disables the upper/lower case switch
                                 <ctrl I> - enables the upper/lower case switch
                                 <ctrl S> - homes the cursor
-                                <ctrl T> - delets character
+                                <ctrl T> - deletes character
                                 Note that the italic keys only represent a ASCII code, and
                                 not a CBM character.
 .:EC78 FF FF FF FF FF FF FF FF
@@ -1823,14 +1823,14 @@
                                 *** VIDEO CHIP SET UP TABLE
                                 This is a table of the initial values for the VIC chip
                                 registers at start up.
-.:ECB9 00 00                    $d000/1, sprite0 - x,y cordinate
-.:ECBB 00 00                    $d002/3, sprite1 - x,y cordinate
-.:ECBD 00 00                    $d004/5, sprite2 - x,y cordinate
-.:ECBF 00 00                    $d006/7, sprite3 - x,y cordinate
-.:ECC1 00 00                    $d008/9, sprite4 - x,y cordinate
-.:ECC3 00 00                    $d00a/b, sprite5 - x,y cordinate
-.:ECC5 00 00                    $d00c/d, sprite6 - x,y cordinate
-.:ECC7 00 00                    $d00e/f, sprite7 - x,y cordinate
+.:ECB9 00 00                    $d000/1, sprite0 - x,y coordinate
+.:ECBB 00 00                    $d002/3, sprite1 - x,y coordinate
+.:ECBD 00 00                    $d004/5, sprite2 - x,y coordinate
+.:ECBF 00 00                    $d006/7, sprite3 - x,y coordinate
+.:ECC1 00 00                    $d008/9, sprite4 - x,y coordinate
+.:ECC3 00 00                    $d00a/b, sprite5 - x,y coordinate
+.:ECC5 00 00                    $d00c/d, sprite6 - x,y coordinate
+.:ECC7 00 00                    $d00e/f, sprite7 - x,y coordinate
 .:ECC9 00                       $d010, sprite MSB
 .:ECCA 9B                       $d011, VIC control register
 .:ECCB 37                       $d012,
@@ -1888,7 +1888,7 @@
                                 (#$3f) and UNLISTEN (#$5f) are also sent via this routine,
                                 but their values are set on entry. If there is a character
                                 waiting to go out on the bus, then this is output.
-                                Handshaking is performed, and ATN (attension) is set low
+                                Handshaking is performed, and ATN (attention) is set low
                                 so that the byte is interpreted as a command. The routine
                                 drops through to the next one to output the byte on the
                                 serial bus. Note that on conclusion, ATN must be set high.
@@ -1993,19 +1993,19 @@
 .,EDB2 20 1C FE JSR $FE1C       set I/O status word
 .,EDB5 58       CLI
 .,EDB6 18       CLC
-.,EDB7 90 4A    BCC $EE03       allways jump, do final handshake
+.,EDB7 90 4A    BCC $EE03       always jump, do final handshake
 
                                 *** SECOND: SEND LISTEN SA
                                 The KERNAL routine SECOND ($ff93) is vectored here. On
                                 entry, (A) holds the secondary address. This is placed in
                                 the serial buffer and sent to the serial bus "under
-                                attension". Finally the routine drops through to the next
+                                attention". Finally the routine drops through to the next
                                 routine to set ATN false.
 .,EDB9 85 95    STA $95         store (A) in BSOUT, buffer for the serial bus
 .,EDBB 20 36 ED JSR $ED36       handshake and send byte.
 
                                 *** CLEAR ATN
-                                The ATN, attension, line on the serial bus is set to 1,
+                                The ATN, attention, line on the serial bus is set to 1,
                                 ie. ATN is now false and data sent on the serial bus will
                                 not be interpreted as a command.
 .,EDBE AD 00 DD LDA $DD00       serial bus I/O port
@@ -2017,14 +2017,14 @@
                                 The KERNAL routine TKSA ($ff96) is vectored here. On
                                 entry, (A) holds the secondary address. This is placed in
                                 the serial buffer and sent out to the serial bus "under
-                                attension". The routine drops through to the next routine
+                                attention". The routine drops through to the next routine
                                 to wait for CLK and clear ATN.
 .,EDC7 85 95    STA $95         BSOUR, the serial bus buffer
 .,EDC9 20 36 ED JSR $ED36       handshake and send byte to the bus
 
                                 *** WAIT FOR CLOCK
                                 This routine sets data = 0, ATN = 1 and CLK = 1. It then
-                                waits to recieve CLK = 0 from the serial bus.
+                                waits to receive CLK = 0 from the serial bus.
 .,EDCC 78       SEI             disable interrupts
 .,EDCD 20 A0 EE JSR $EEA0       set data 0
 .,EDD0 20 BE ED JSR $EDBE       set ATN 1
@@ -2077,13 +2077,13 @@
 
                                 *** ACPTR: RECIEVE FROM SERIAL BUS
                                 The KERNAL routine ACPTR ($ffa5) points to this routine. A
-                                timing loop is enteredusing the CIA timer, and if a byte
+                                timing loop is entered using the CIA timer, and if a byte
                                 is not received in 65 ms, ST is set to #$02, ie. a read
                                 timeout. A test is made for EOI and if this occurs, ST is
                                 set to #$40, indicating end of file. The byte is then
                                 received from the serial bus and built up bit by bit in
-                                the temporary stora at #$a4. This is transfered to (A) on
-                                exit, unless EOI has occured.
+                                the temporary store at #$a4. This is transferred to (A) on
+                                exit, unless EOI has occurred.
 .,EE13 78       SEI
 .,EE14 A9 00    LDA #$00
 .,EE16 85 A5    STA $A5         CNTDN, counter
@@ -2174,11 +2174,11 @@
 
                                 *** GET SERIAL DATA AND CLOCK IN
                                 The serial port I/O register is stabilised and read. The
-                                data is shifteed into carry and CLK into bit 7. This way,
+                                data is shifted into carry and CLK into bit 7. This way,
                                 both the data and clock can bee determined by flags in the
                                 processor status register. Note that the values read are
-                                true, and do not nead to be reversed in the same way as
-                                the outuput line do.
+                                true, and do not need to be reversed in the same way as
+                                the output line do.
 .,EEA9 AD 00 DD LDA $DD00       serial port I/O register
 .,EEAC CD 00 DD CMP $DD00       compare
 .,EEAF D0 F8    BNE $EEA9       wait for bus to settle
@@ -2193,7 +2193,7 @@
 .,EEB3 8A       TXA             move (X) to (A)
 .,EEB4 A2 B8    LDX #$B8        start value
 .,EEB6 CA       DEX             decrement
-.,EEB7 D0 FD    BNE $EEB6       untill zero
+.,EEB7 D0 FD    BNE $EEB6       until zero
 .,EEB9 AA       TAX             (A) to (X)
 .,EEBA 60       RTS
 
@@ -2223,8 +2223,8 @@
 .,EED4 85 B5    STA $B5         NXTBIT, next RS232 bit to send
 .,EED6 60       RTS
 .,EED7 A9 20    LDA #$20
-.,EED9 2C 94 02 BIT $0294       M51CDR, 6551 command register immage
-.,EEDC F0 14    BEQ $EEF2       no patity
+.,EED9 2C 94 02 BIT $0294       M51CDR, 6551 command register image
+.,EEDC F0 14    BEQ $EEF2       no parity
 .,EEDE 30 1C    BMI $EEFC       mark/space transmit
 .,EEE0 70 14    BVS $EEF6       even parity
 .,EEE2 A5 BD    LDA $BD         ROPRTY, out parity
@@ -2249,7 +2249,7 @@
                                 *** SEND NEW RS232 BYTE
                                 This routine sets up the system variables ready to send a
                                 new byte to the RS232 port. A test is made for 3-line or
-                                X-line modus. In X-line mode, DSR and  CTS are checked.
+                                X-line mode. In X-line mode, DSR and  CTS are checked.
 .,EF06 AD 94 02 LDA $0294       M51CDR, 6551 command register
 .,EF09 4A       LSR             test handshake mode
 .,EF0A 90 07    BCC $EF13       3-line mode (no handshake)
@@ -2345,8 +2345,8 @@
 .,EF8D 4C 3B EF JMP $EF3B       disable timer and exit
 
                                 *** PROCESS RS232 BYTE
-                                The byte recieved from the RS232 port is checked against
-                                parity. This involvs checking the input parity options
+                                The byte received from the RS232 port is checked against
+                                parity. This involves checking the input parity options
                                 selected, and then verifying the parity bit calculated
                                 against that input. If the test is passed, then the byte
                                 is stored in the in-buffer. Otherwise an error is flagged
@@ -2398,7 +2398,7 @@
                                 *** SUBMIT TO RS232
                                 This routine is called when data is required from the
                                 RS232 port. Its function is to perform the handshaking on
-                                the poort needed to receive the data. If 3 line mode is
+                                the port needed to receive the data. If 3 line mode is
                                 used, then no handshaking is implemented and the routine
                                 exits.
 .,EFE1 85 9A    STA $9A         DFLTO, default output device
@@ -2548,7 +2548,7 @@
                                 control which message is printed. The routine tests if we
                                 are in program mode or direct mode. If in program mode,
                                 the routine exits. Else, the routine prints character
-                                after caracter untill it reaches a character with bit7
+                                after character until it reaches a character with bit7
                                 set.
 .,F12B 24 9D    BIT $9D         MSGFLG, test if direct or program mode
 .,F12D 10 0D    BPL $F13C       program mode, don't print message
@@ -2558,7 +2558,7 @@
 .,F135 20 D2 FF JSR $FFD2       output character using CHROUT
 .,F138 C8       INY             increment pointer to next character
 .,F139 28       PLP             retrieve message
-.,F13A 10 F3    BPL $F12F       untill bit7 was set
+.,F13A 10 F3    BPL $F12F       until bit7 was set
 .,F13C 18       CLC             clear carry to indicate no error
 .,F13D 60       RTS
 
@@ -2639,10 +2639,10 @@
 
                                 *** GET FROM SERIAL/RS232
                                 These routines, actually two different, is entered from
-                                the previous routine. The serial sectionchecks the state
-                                of ST. If zero, then the data is recieved from the bus,
+                                the previous routine. The serial section checks the state
+                                of ST. If zero, then the data is received from the bus,
                                 otherwise carriage return (#0d) is returned in (A). In the
-                                second section, the recieved byte is read from the RS232
+                                second section, the received byte is read from the RS232
                                 port.
 .,F1AD A5 90    LDA $90         STATUS, I/O status word
 .,F1AF F0 04    BEQ $F1B5       status OK
@@ -2728,7 +2728,7 @@
 .,F223 C9 02    CMP #$02        RS232
 .,F225 D0 03    BNE $F22A       nope
 .,F227 4C 4D F0 JMP $F04D       input from RS232
-.,F22A A6 B9    LDX $B9         SA, current secondart address
+.,F22A A6 B9    LDX $B9         SA, current secondary address
 .,F22C E0 60    CPX #$60
 .,F22E F0 03    BEQ $F233
 .,F230 4C 0A F7 JMP $F70A       I/O error #6, not output file
@@ -2749,7 +2749,7 @@
 
                                 *** CHKOUT: SET OUTPUT DEVICE
                                 The KERNAL routine CHKOUT ($ffc9) is vectored to this
-                                routinr. On entry (X) must hold the logical filenumber. A
+                                routine. On entry (X) must hold the logical filenumber. A
                                 test is made to see if the file is open, or ?FILE NOT OPEN
                                 error. If the device is 0, ie. the keyboard, or the file
                                 is not an output file, then ?FILE OUTPUT FILE error is
@@ -2774,7 +2774,7 @@
 .,F271 E0 60    CPX #$60
 .,F273 F0 EA    BEQ $F25F       not output file error
 .,F275 85 9A    STA $9A         DFLTO, default output device
-.,F277 18       CLC             clear carry to incicate no errors
+.,F277 18       CLC             clear carry to indicate no errors
 .,F278 60       RTS
 .,F279 AA       TAX             file (X) to (A)
 .,F27A 20 0C ED JSR $ED0C       send LISTEN to serial device
@@ -2853,7 +2853,7 @@
 .,F2F5 E4 98    CPX $98         compare LDTND to (X)
 .,F2F7 F0 14    BEQ $F30D       equal, closed file = last file in table
 .,F2F9 A4 98    LDY $98         else, move last entry to position of closed entry
-.,F2FB B9 59 02 LDA $0259,Y     LAT, active filenumbers
+.,F2FB B9 59 02 LDA $0259,Y     LAT, active file numbers
 .,F2FE 9D 59 02 STA $0259,X
 .,F301 B9 63 02 LDA $0263,Y     FAT, active device numbers
 .,F304 9D 63 02 STA $0263,X
@@ -2919,7 +2919,7 @@
 
                                 *** OPEN: OPEN FILE
                                 The KERNAL routine OPEN ($ffc0) is vectored here. The file
-                                paramerters must be set before entry. The routine reads
+                                parameters must be set before entry. The routine reads
                                 the LAT, to see if file already exists, which will result
                                 in I/O error #2, ?FILE OPEN. A test is made to see if more
                                 than 10 files are open. If so, I/O error #1, ?TOO MANY
@@ -2927,7 +2927,7 @@
                                 their respective tables. The device number is checked, and
                                 each kind of device jumps to their own routine. Keyboard
                                 and screen will exit here with no further actions. RS232
-                                is opened via a seperate routine. SA, secondary address,
+                                is opened via a separate routine. SA, secondary address,
                                 and filename will be sent on the serial bus.
 .,F34A A6 B8    LDX $B8         LA, current logical number
 .,F34C D0 03    BNE $F351
@@ -2943,7 +2943,7 @@
 .,F364 A5 B8    LDA $B8         LA
 .,F366 9D 59 02 STA $0259,X     store in LAT, table of active file numbers
 .,F369 A5 B9    LDA $B9         SA
-.,F36B 09 60    ORA #$60        fixx
+.,F36B 09 60    ORA #$60        fix
 .,F36D 85 B9    STA $B9         store in SA
 .,F36F 9D 6D 02 STA $026D,X     store in SAT, table of active secondary addresses
 .,F372 A5 BA    LDA $BA         FA
@@ -2995,7 +2995,7 @@
 
                                 *** SEND SA
                                 This routine exits if there is no secondary address or
-                                filename specifyed. The I/O status word, ST, is reset, and
+                                filename specified. The I/O status word, ST, is reset, and
                                 the serial device is commanded to LISTEN. A check is made
                                 for a possible ?DEVICE NOT PRESENT error. Finally, the
                                 filename is sent to the device.
@@ -3092,7 +3092,7 @@
 .,F49D 60       RTS
 
                                 *** LOAD: LOAD RAM
-                                The kernal routine LOAD ($ffd5) is vectoed here. If a
+                                The kernal routine LOAD ($ffd5) is vectored here. If a
                                 relocated load is desired, then the start address is set
                                 in MEMUSS. The load/verify flag is set, and the I/O status
                                 word is reset. A test is done on the device number, less
@@ -3114,12 +3114,12 @@
                                 sent with the TALK command and secondary address to the
                                 serial bus. If EOI occurs at this point, then ?FILE NOT
                                 FOUND is displayed. The message 'LOADING' or 'VERIFYING'
-                                is output and a loop is entered, which recieves a byte
+                                is output and a loop is entered, which receives a byte
                                 from the serial bus, checks the <STOP> key and either
                                 stores the received byte, or compares it to the memory,
                                 depending on the state of VERCK. Finally the bus is
                                 UNTALKed.
-.,F4B6 90 7B    BCC $F533       device < 3, eg tape or RS232, illegal device
+.,F4B6 90 7B    BCC $F533       device < 3, e.g. tape or RS232, illegal device
 .,F4B8 A4 B7    LDY $B7         FNLEN, length of filename
 .,F4BA D0 03    BNE $F4BF       if length not is zero
 .,F4BC 4C 10 F7 JMP $F710       'MISSING FILENAME'
@@ -3138,7 +3138,7 @@
 .,F4DC 4A       LSR
 .,F4DD 4A       LSR
 .,F4DE B0 50    BCS $F530       EOI set, file not found
-.,F4E0 20 13 EE JSR $EE13       recieve from serial bus
+.,F4E0 20 13 EE JSR $EE13       receive from serial bus
 .,F4E3 85 AF    STA $AF         load address, >EAL
 .,F4E5 8A       TXA             retrieve SA and test relocated load
 .,F4E6 D0 08    BNE $F4F0
@@ -3153,7 +3153,7 @@
 .,F4F9 20 E1 FF JSR $FFE1       scan <STOP>
 .,F4FC D0 03    BNE $F501       not stopped
 .,F4FE 4C 33 F6 JMP $F633
-.,F501 20 13 EE JSR $EE13      ACPTR, recrive from serial bus
+.,F501 20 13 EE JSR $EE13      ACPTR, receive from serial bus
 .,F504 AA       TAX
 .,F505 A5 90    LDA $90
 .,F507 4A       LSR
@@ -3164,7 +3164,7 @@
 .,F50E F0 0C    BEQ $F51C       jump to LOAD
 .,F510 A0 00    LDY #$00
 .,F512 D1 AE    CMP ($AE),Y     compare with memory
-.,F514 F0 08    BEQ $F51E       veryfied byte OK
+.,F514 F0 08    BEQ $F51E       verified byte OK
 .,F516 A9 10    LDA #$10
 .,F518 20 1C FE JSR $FE1C
 .:F51B 2C       .BYTE $2C       mask next write command
@@ -3241,7 +3241,7 @@
 
                                 *** LOAD END
                                 This is the last part of the loader routine which sets the
-                                (X/Y) register with the endaddress of the loaded program,
+                                (X/Y) register with the end address of the loaded program,
                                 clears carry and exit.
 .,F5A9 18       CLC
 .,F5AA A6 AE    LDX $AE
@@ -3291,7 +3291,7 @@
                                 entry, (X/Y) must hold the end address+1 of the area of
                                 memory to be saved. (A) holds the pointer to the start
                                 address of the block, held in zeropage. The current device
-                                number is checked to ensure that it is niether keyboard
+                                number is checked to ensure that it is neither keyboard
                                 (0) or screen (3). Both of these result in ?ILLEGAL DEVICE
                                 NUMBER.
 .,F5DD 86 AE    STX $AE         EAL , end address of block +1
@@ -3315,7 +3315,7 @@
                                 and the filename is sent along with the secondary address.
                                 The message 'SAVING' is printed, and a loop sends a byte
                                 to the serial bus and checks <STOP> key until the whole
-                                specifyed block of memory has been saved. Note that the
+                                specified block of memory has been saved. Note that the
                                 first two bytes sent are the start address of the block.
                                 Finally the serial bus is UNLISTENed.
 .,F5FA A9 61    LDA #$61
@@ -3411,7 +3411,7 @@
 .,F6A3 D0 02    BNE $F6A7
 .,F6A5 E6 A0    INC $A0         high byte of jiffy clock
 .,F6A7 38       SEC
-.,F6A8 A5 A2    LDA $A2         substract $4f1a01
+.,F6A8 A5 A2    LDA $A2         subtract $4f1a01
 .,F6AA E9 01    SBC #$01
 .,F6AC A5 A1    LDA $A1
 .,F6AE E9 1A    SBC #$1A
@@ -3434,7 +3434,7 @@
 .,F6C9 8E 00 DC STX $DC00       keyboard write register
 .,F6CC AE 01 DC LDX $DC01       keyboard read register
 .,F6CF EC 01 DC CPX $DC01
-.,F6D2 D0 F8    BNE $F6CC       wiat for value to settle
+.,F6D2 D0 F8    BNE $F6CC       wait for value to settle
 .,F6D4 8D 00 DC STA $DC00
 .,F6D7 E8       INX
 .,F6D8 D0 02    BNE $F6DC
@@ -3456,11 +3456,11 @@
                                 *** SETTIM: SET TIME
                                 The KERNAL routine SETTIM ($ffdb) jumps to this routine.
                                 On entry, (A/X/Y) must hold the value to be stored in the
-                                clock. The forman is high/mid/low, and clock resolution is
+                                clock. The format is high/mid/low, and clock resolution is
                                 1/60 second. SEI is included since part of the IRQ routine
                                 is to update the clock.
 .,F6E4 78       SEI             disable interrupt
-.,F6E5 85 A2    STA $A2         wrine TIME
+.,F6E5 85 A2    STA $A2         write TIME
 .,F6E7 86 A1    STX $A1
 .,F6E9 84 A0    STY $A0
 .,F6EB 58       CLI             enable interrupts
@@ -3468,7 +3468,7 @@
 
                                 *** STOP: CHECK <STOP> KEY
                                 The KERNAL routine STOP ($ffe1) is vectored here. If STKEY
-                                =#7f, then <STOP> was pressed and logged whilest the jiffy
+                                =#7f, then <STOP> was pressed and logged whilst the jiffy
                                 clock was being updated, so all I/O channels are closed
                                 and the keyboard buffer reset.
 .,F6ED A5 91    LDA $91         STKEY
@@ -4240,10 +4240,10 @@
                                 is the first routine executed when the computer is
                                 switched on. The routine firstly sets the stackpointer to
                                 #ff, disables interrupts and clears the decimal flag. It
-                                jumps to a routine at $fd02 which checks for autostart-
-                                cartridges. If so, an indirectjump is performed to the
+                                jumps to a routine at $fd02 which checks for autostart
+                                cartridges. If so, an indirect jump is performed to the
                                 cartridge coldstart vector at $8000. I/O chips are
-                                initiated, and system constants are set up. Finaly the IRQ
+                                initiated, and system constants are set up. Finally the IRQ
                                 is enabled, and an indirect jump is performed to $a000,
                                 the basic cold start vector.
 .,FCE2 A2 FF    LDX #$FF
@@ -4252,7 +4252,7 @@
 .,FCE6 D8       CLD
 .,FCE7 20 02 FD JSR $FD02       Check ROM at $8000
 .,FCEA D0 03    BNE $FCEF
-.,FCEC 6C 00 80 JMP ($8000)     Jump to autostartvector
+.,FCEC 6C 00 80 JMP ($8000)     Jump to autostart vector
 .,FCEF 8E 16 D0 STX $D016
 .,FCF2 20 A3 FD JSR $FDA3       Init I/O
 .,FCF5 20 50 FD JSR $FD50       Init system constants
@@ -4262,10 +4262,10 @@
 .,FCFF 6C 00 A0 JMP ($A000)     Basic coldstart
 
                                 *** CHECK FOR 8-ROM
-                                Checks for the ROM autostartparametrar at $8004-$8008. It
+                                Checks for the ROM autostart parameters at $8004-$8008. It
                                 compares data with $fd10, and if equal, set Z=1.
 .,FD02 A2 05    LDX #$05        5 bytes to check
-.,FD04 BD 0F FD LDA $FD0F,X     Identifyer at $fd10
+.,FD04 BD 0F FD LDA $FD0F,X     Identifier at $fd10
 .,FD07 DD 03 80 CMP $8003,X     Compare with $8004
 .,FD0A D0 03    BNE $FD0F       NOT equal!
 .,FD0C CA       DEX
@@ -4273,15 +4273,15 @@
 .,FD0F 60       RTS
 
                                 *** 8-ROM IDENTIFYER
-                                The following 5 bytes contains the 8-ROM identifyer,
+                                The following 5 bytes contains the 8-ROM identifier,
                                 reading "CBM80" with CBM ASCII. It is used with
-                                autostartcartridges. See $fd02.
+                                autostart cartridges. See $fd02.
 .:FD10 C3 C2 CD 38 30           CBM80
 
 
                                 *** RESTOR: KERNAL RESET
                                 The KERNAL routine RESTOR ($ff8a) jumps to this routine.
-                                It restores (copys) the KERNAL vectors at $fd30 to $0314-
+                                It restores (copies) the KERNAL vectors at $fd30 to $0314-
                                 $0333. Continues through VECTOR.
 .,FD15 A2 30    LDX #$30        $fd30 - table of KERNAL vectors
 .,FD17 A0 FD    LDY #$FD        Clear carry to SET values.
@@ -4289,13 +4289,13 @@
 
                                 *** VECTOR: KERNAL MOVE
                                 The KERNAL routine VECTOR ($ff8d) jumps to this routine.
-                                It reads or sets the vactors at $0314-$0333 depending on
-                                state of carry. X/Y contains the adress to read/write
+                                It reads or sets the vectors at $0314-$0333 depending on
+                                state of carry. X/Y contains the address to read/write
                                 area, normally $fd30. See $fd15.
                                 A problem is that the RAM under the ROM at $fd30 always
                                 gets a copy of the contents in the ROM then you perform
                                 the copy.
-.,FD1A 86 C3    STX $C3         MEMUSS - c3/c4 temporary used for adress
+.,FD1A 86 C3    STX $C3         MEMUSS - c3/c4 temporary used for address
 .,FD1C 84 C4    STY $C4
 .,FD1E A0 1F    LDY #$1F        Number of bytes to transfer
 .,FD20 B9 14 03 LDA $0314,Y
@@ -4308,7 +4308,7 @@
 .,FD2F 60       RTS
 
                                 *** KERNAL RESET VECTORS
-                                These are the vectors that is copyed to $0314-$0333 when
+                                These are the vectors that is copied to $0314-$0333 when
                                 RESTOR is called.
 .:FD30 31 EA                    CINV VECTOR: hardware interrupt ($ea31)
 .:FD32 66 FE                    CBINV VECTOR: software interrupt ($fe66)
@@ -4454,7 +4454,7 @@
                                 The routine checks if the current devicenumber is 2, (ie
                                 RS232) then the value of RSSTAT (the ACIA 6551 status)is
                                 returned in (A), and RSSTAT is cleared. Else it reads and
-                                returnes the value of STATUS.
+                                returns the value of STATUS.
 .,FE07 A5 BA    LDA $BA         read current device number from FA
 .,FE09 C9 02    CMP #$02        device = RS232?
 .,FE0B D0 0D    BNE $FE1A       nope, read STATUS
@@ -4539,7 +4539,7 @@
                                 default values, I/O vectors initialised and a jump to
                                 ($a002), the Basic warm start vector.
                                 The NMI routine continues at $fe72 by checking the RS232,
-                                if there is anyting to send.
+                                if there is anything to send.
 .,FE66 20 15 FD JSR $FD15       KERNAL reset
 .,FE69 20 A3 FD JSR $FDA3       init I/O
 .,FE6C 20 18 E5 JSR $E518       init I/O
@@ -4550,7 +4550,7 @@
 .,FE73 2D A1 02 AND $02A1       mask with ENABL, RS232 enable
 .,FE76 AA       TAX             temp store in (X)
 .,FE77 29 01    AND #$01        test if sending (%00000001)
-.,FE79 F0 28    BEQ $FEA3       nope, jump to recieve test
+.,FE79 F0 28    BEQ $FEA3       nope, jump to receive test
 .,FE7B AD 00 DD LDA $DD00       load CIA#1 DRA
 .,FE7E 29 FB    AND #$FB        mask bit2 (RS232 send)
 .,FE80 05 B5    ORA $B5         NXTBIT, next bit to send
@@ -4558,10 +4558,10 @@
 .,FE85 AD A1 02 LDA $02A1
 .,FE88 8D 0D DD STA $DD0D       write ENABL to CIA#2 I.C.R
 .,FE8B 8A       TXA             get temp
-.,FE8C 29 12    AND #$12        test if recieving (bit1), or waiting for reciever
+.,FE8C 29 12    AND #$12        test if receiving (bit1), or waiting for receiver
                                 edge (bit4) ($12 = %00010010)
-.,FE8E F0 0D    BEQ $FE9D       nope, skip reciever routine
-.,FE90 29 02    AND #$02        test if recieving
+.,FE8E F0 0D    BEQ $FE9D       nope, skip receiver routine
+.,FE90 29 02    AND #$02        test if receiving
 .,FE92 F0 06    BEQ $FE9A       nope
 .,FE94 20 D6 FE JSR $FED6       jump to NMI RS232 in
 .,FE97 4C 9D FE JMP $FE9D
@@ -4587,8 +4587,8 @@
 .,FEC1 40       RTI             back from NMI
 
                                 *** RS232 TIMING TABLE - NTSC
-                                Timingtable for RS232 NMI for use with NTSC machines. The
-                                table containe 10 entries which corresponds to one of the
+                                Timing table for RS232 NMI for use with NTSC machines. The
+                                table contains 10 entries which corresponds to one of the
                                 fixed RS232 rates, starting with lowest (50 baud) and
                                 finishing with the highest (2400 baud). Since the clock
                                 frequency is different between NTSC and PAL systems, there
@@ -4607,7 +4607,7 @@
                                 *** NMI RS232 IN
                                 This routine inputs a bit from the RS232 port and sets the
                                 baudrate timing for the next bit. Continues to the RS232
-                                recieve routine.
+                                receive routine.
 .,FED6 AD 01 DD LDA $DD01       RS232 I/O port
 .,FED9 29 01    AND #$01        test bit0, received data
 .,FEDB 85 A7    STA $A7         store in INBIT
@@ -4692,7 +4692,7 @@
 .,FF5B 20 18 E5 JSR $E518       original I/O init
 .,FF5E AD 12 D0 LDA $D012       wait for top of screen
 .,FF61 D0 FB    BNE $FF5E       at line zero
-.,FF63 AD 19 D0 LDA $D019       Check IRQ flag register if interrupt occured
+.,FF63 AD 19 D0 LDA $D019       Check IRQ flag register if interrupt occurred
 .,FF66 29 01    AND #$01        only first bit
 .,FF68 8D A6 02 STA $02A6       store in PAL/NTSC flag
 .,FF6B 4C DD FD JMP $FDDD       jump to ENABLE TIMER
@@ -4701,7 +4701,7 @@
                                 This routine starts the CIA#1 timer and jumps into a
                                 routine that handles the serial clock.
 .,FF6E A9 81    LDA #$81        Enable IRQ when timer B reaches zero
-.,FF70 8D 0D DC STA $DC0D       CIA#1 interrupt controll register
+.,FF70 8D 0D DC STA $DC0D       CIA#1 interrupt control register
 .,FF73 AD 0E DC LDA $DC0E       CIA#1 control register A
 .,FF76 29 80    AND #$80
 .,FF78 09 11    ORA #$11        Force load of timer A values -bit4, and start -bit0
@@ -4743,7 +4743,7 @@
 .,FFC6 6C 1E 03 JMP ($031E)     CHKIN, prepare channel for input
 .,FFC9 6C 20 03 JMP ($0320)     CHKOUT, prepare channel for output
 .,FFCC 6C 22 03 JMP ($0322)     CLRCHN, close all I/O
-.,FFCF 6C 24 03 JMP ($0324)     CHRIN, inpup byte from channel
+.,FFCF 6C 24 03 JMP ($0324)     CHRIN, input byte from channel
 .,FFD2 6C 26 03 JMP ($0326)     CHROUT, output byte to channel
 .,FFD5 4C 9E F4 JMP $F49E       LOAD, load from serial device
 .,FFD8 4C DD F5 JMP $F5DD       SAVE, save to serial device

--- a/src/c64disasm/c64disasm_sc.txt
+++ b/src/c64disasm/c64disasm_sc.txt
@@ -8,7 +8,7 @@
 - as found in the ROMs of the Apple II. C64 BASIC V2 and Applesoft BASIC
 - are both based on Microsoft BASIC for 6502, albeit on different versions,
 - and they both add incompatible extensions. Nevertheless, they are still
-- extremely similar, so that Bob Sander-Cederlof's Applestoft comments could
+- extremely similar, so that Bob Sander-Cederlof's Applesoft comments could
 - be semi-automatically ported over to the version of BASIC in the ROM of
 - the Commodore 64.
 -

--- a/src/c64io/c64io_mapc64.txt
+++ b/src/c64io/c64io_mapc64.txt
@@ -182,7 +182,7 @@ $D000-$D02E               VIC-II Chip Registers
 
                           As you can see, the first and last bytes are all 0's, so nothing will
                           be displayed there.  The middle byte has six 1's, so it will be
-                          displayed as a line six dots long.  By adding the values of these dix
+                          displayed as a line six dots long.  By adding the values of these six
                           bits (64+32+16+8+4+2), we get a byte value of 126.  Let's try another
                           line.
 
@@ -411,10 +411,10 @@ $D011        SCROY        Vertical Fine Scrolling and Control Register
                           scroll bits goes from 7 to 0, or from 0 to 7.  This is accomplished by
                           moving the display data for each line by 40 bytes in either direction,
                           overwriting the data for the last line, and introducing a line of data
-                          at the opposite end of screen memory to replace it.  Obviously, ony a
+                          at the opposite end of screen memory to replace it.  Obviously, only a
                           machine language program can move all of these lines quickly enough to
                           maintain the effect of smooth motion.  The following BASIC program,
-                          however, will give you an iea of what vertical fine scrolling is like:
+                          however, will give you an idea of what vertical fine scrolling is like:
 
                               10 POKE 53281,0:PRINTCHR$(5);CHR$(147)
                               20 FORI=1 TO 27:
@@ -447,7 +447,7 @@ $D011        SCROY        Vertical Fine Scrolling and Control Register
                           Bit 4.  Bit 4 of this register controls the screen blanking feature.
                           When this bit is set to 0, no data can be displayed on the screen.
                           Instead, the whole screen will be filled with the color of the frame
-                          (which is controlled by th eBorder Color Register at 53280 ($D020)).
+                          (which is controlled by the Border Color Register at 53280 ($D020)).
 
                           Screen blanking is useful because of the way in which the VIC-II chip
                           interacts with the 6510 microprocessor.  Since the VIC-II and the 6510
@@ -458,7 +458,7 @@ $D011        SCROY        Vertical Fine Scrolling and Control Register
                           The VIC-II chip was designed so that it fetches most of the data it
                           needs during the part of the cycle in which the 6510 is not using the
                           data bus.  But certain operations, such as reading the 40 screen codes
-                          needed for each line of text from video mmeory, or fetching sprite
+                          needed for each line of text from video memory, or fetching sprite
                           data, require that the VIC-II chip get data at a faster rate than is
                           possible just by using the off half of the 6510 cycle.
 
@@ -598,7 +598,7 @@ $D011        SCROY        Vertical Fine Scrolling and Control Register
                           fairly easy to transfer text characters to a bitmap screen, but it is
                           somewhat awkward finding the bit which affects the screen dot having a
                           given X-Y coordinate.  First, you must find the byte BY in which the
-                          bit resides, and then you must POKE a vlue into that byte which turns
+                          bit resides, and then you must POKE a value into that byte which turns
                           the desired bit on or off.  Given that the horizontal position of the
                           dot is stored in the variable X, its vertical position is in the
                           variable Y, and the base address of the bitmap area is in the variable
@@ -614,7 +614,7 @@ $D011        SCROY        Vertical Fine Scrolling and Control Register
 
                               POKE BY, PEEK(BY) AND (255-2^(NOTX AND 7))
 
-                          The exponentation function takes a lot of time.  To speed things up,
+                          The exponentiation function takes a lot of time.  To speed things up,
                           an array can be created, each of whose elements corresponds to a power
                           of two.
 
@@ -639,9 +639,9 @@ $D011        SCROY        Vertical Fine Scrolling and Control Register
                               120 GOTO 120: REM LET IT STAY ON SCREEN
 
                           As you can see, using BASIC to draw in bit-graphics mode is somewhat
-                          slow and tedious.  Machine language is much more suiable for
+                          slow and tedious.  Machine language is much more suitable for
                           bit-graphics plotting.  For a program that lets you replace some BASIC
-                          ommands with high-res drawing commands, see the article "Hi-Res
+                          commands with high-res drawing commands, see the article "Hi-Res
                           Graphics Made Simple," by Paul F. Schatz, in COMPUTE!'s First Book of
                           Commodore 64 Sound and Graphics.
 
@@ -1015,7 +1015,7 @@ $D016        SCROLX       Horizontal Fine Scrolling and Control Register
 
                           If you are not in bitmap mode, and you select multicolor text
                           character mode by setting this bit to 1, characters with a color
-                          nybble whose value is less than 8 are displyed normally.  There will
+                          nybble whose value is less than 8 are displayed normally.  There will
                           be one background color and one foreground color.  But each dot of a
                           character with a color nybble whose value is over 7 can have any one
                           of four different colors.
@@ -1064,7 +1064,7 @@ $D016        SCROLX       Horizontal Fine Scrolling and Control Register
 
                           Given that the horizontal position (0-159) of the dot is stored in the
                           variable X, its vertical position is in the variable Y, and the base
-                          address of the bitmap area ia in the variable BASE, you can find the
+                          address of the bitmap area is in the variable BASE, you can find the
                           desired byte with the formula:
 
                           BY=BASE+(Y AND 248)*40+(Y AND 7)+(2*X AND 504)
@@ -1197,7 +1197,7 @@ $D018        VMCSB        VIC-II Chip Memory Control Register
                           of VIC- II memory, and the video chip is using Bank 2 (32768-49151),
                           the actual starting address of screen memory is 32768+1024=33792
                           ($8400).  For examples of how to change the video memory area, and of
-                          how to relocate the screen, see the entro for 56576 ($DD00).
+                          how to relocate the screen, see the entry for 56576 ($DD00).
 
 $D019        VICIRQ       VIC Interrupt Flag Register
 
@@ -1308,7 +1308,7 @@ $D01A        IRQMASK      IRQ Mask Register
                           At the exact moment that the raster beam line number equals the number
                           written to the register, Bit 0 of the status register will be set to
                           1, showing that the conditions for a Raster Compare Interrupt have
-                          been fulfulled.  If the raster interrupt is enabled then,
+                          been fulfilled.  If the raster interrupt is enabled then,
                           simultaneously, the interrupt program will be executed.  This allows
                           the user to reset any of the VIC-II registers at any point in the
                           display, and thus change character sets, background color, or graphics
@@ -1363,7 +1363,7 @@ $D01A        IRQMASK      IRQ Mask Register
                           Another thing that you should keep in mind is that at least two raster
                           interrupts are required if you want to change only a part of the
                           screen.  Not only must the interrupt routine change the display, but
-                          it must also set up another raster interrput that will change it back.
+                          it must also set up another raster interrupt that will change it back.
 
                           The sample program below uses a raster-scan interrupt to divide the
                           display into three sections.  The first 80 scan lines are in
@@ -1387,7 +1387,7 @@ $D01A        IRQMASK      IRQ Mask Register
                           If you look at lines 49264-49276 of the BASIC program, you will see
                           REMark statements that explain which VIC-II registers are affected by
                           the DATA statements in each line.  The number in these DATA
-                          startements appear in the reverse order in which they are put into the
+                          statements appear in the reverse order in which they are put into the
                           VIC register.  For example, line 49273 holds the data that will go
                           into Control Register 2.  The last number, 8, is the one that will be
                           placed into Control Register 2 while the top part of the screen is
@@ -1486,7 +1486,7 @@ $D01A        IRQMASK      IRQ Mask Register
                           registers (53267-8, $D013-4).
 
                           Bit 2 enables the sprite-foreground collision interrupt.  This
-                          interrupt can occur if one of the srpte character's dots is touching
+                          interrupt can occur if one of the sprite character's dots is touching
                           one of the dots from the foreground display of either text character
                           or bitmap graphics.
 
@@ -1701,7 +1701,7 @@ $D022        BGCOL1       Background Color 1
 $D023        BGCOL2       Background Color 2
 
                           This register sets the color for the 10 bit-pair of multicolor
-                          character graphics, and the background color for characters habing
+                          character graphics, and the background color for characters having
                           screen codes 128-191 in extended background color text mode.  The
                           default color value is 2 (red).
 
@@ -1795,7 +1795,7 @@ $D400-$D41C               Sound Interface Device (SID) Registers
                           the Control Register.  The waveform control lets you select one of
                           four different waveforms, each of which has varying harmonic content
                           that affects the tone quality of the sound.  By writing a 1 to the
-                          gate bit, you start the Attack/ Delay/Sustain cycle.  Afer rising to a
+                          gate bit, you start the Attack/ Delay/Sustain cycle.  After rising to a
                           peak and declining to the Sustain volume, the volume will continue at
                           the same level until you write a 0 to the gate bit.  Then, the Release
                           cycle will start.  Make sure that you keep the same waveform bit set
@@ -1914,7 +1914,7 @@ $D404        VCREG1       Voice 1 Control Register
                           1.  It can be used to imitate the sound of explosions, drums, and
                           other unpitched noises.
 
-                          One of the four waveforms must be chosed in order to create a sound.
+                          One of the four waveforms must be chosen in order to create a sound.
                           Setting more than one of these bits will result in a logical ANDing of
                           the waveforms.  Particularly, the combination of the noise waveform
                           and another is not recommended.
@@ -1929,7 +1929,7 @@ $D405-$D406               Voice 1 Envelope (ADSR) Control
                           The first phase of the envelope, in which the volume builds to a peak,
                           is known as the attack phase.  The second, in which it declines to an
                           intermediate level, is called the decay phase.  The third, in which
-                          the intermediate leve of volume is held, is known as the sustain
+                          the intermediate level of volume is held, is known as the sustain
                           period.  The final interval, in which the sound fades away, is called
                           the release part of the cycle.
 
@@ -2207,7 +2207,7 @@ $D419-$D41A               Game Paddle Inputs
                           the voltage to two pins of the SID chip between 0 and +5 volts.
                           Analog-to-digital (A/D) converters in the chip interpret these voltage
                           levels as binary values and store the values in these registers.
-                          These registers return a number from 0 (minumum resistance) to 255
+                          These registers return a number from 0 (minimum resistance) to 255
                           (maximum resistance) for each paddle in either of the ports, depending
                           on the position of the paddle knob.
 
@@ -2241,7 +2241,7 @@ $D419-$D41A               Game Paddle Inputs
                           Port B, if Bit 2 is set to 0, button 3 is pushed, and if Bit 3 is set
                           to 0, button 4 is pushed.
 
-                          The BASIC statements to test these buttons, thereore, are:
+                          The BASIC statements to test these buttons, therefore, are:
 
                               PB(1)=(PEEK(56321)AND4)/4
                               PB(2)=(PEEK(56321)AND8)/8
@@ -2389,7 +2389,7 @@ $D800-$DBFF               Color RAM
                           clear the screen, and return the background color in the desired
                           value.
 
-                          The various garphics modes use this area differently than does the
+                          The various graphics modes use this area differently than does the
                           regular text mode.  In high-resolution bitmap mode, this area is not
                           used at all, but in multicolor bitmap mode it is used to determine the
                           color of the 11 bit-pair for a given 8 by 8 dot area.
@@ -2644,7 +2644,7 @@ $DC02-$DC03               CIA #1 Data Direction Registers A and B
 
                           These Data Direction Registers control the direction of data flow over
                           Data Ports A and B.  Each bit controls the direction of the data on
-                          the corresponding bit of the port.  If teh bit of the Direction
+                          the corresponding bit of the port.  If the bit of the Direction
                           Register is set to a 1, the corresponding Data Port bit will be used
                           for data output.  If the bit is set to a 0, the corresponding Data
                           Port bit will be used for data input.  For example, Bit 7 of Data
@@ -3092,7 +3092,7 @@ $DD00-$DD01               CIA #2 Data Ports A and B
                           however, the Serial Bus is at least eight times slower than the IEEE.
                           It is presently used to control the 1541 Disk Drive and 1525 printer,
                           and other devices (such as printer interface for Centronics- type
-                          parallel pritners and stringy floppy wafer tape storage units) can be
+                          parallel printers and stringy floppy wafer tape storage units) can be
                           placed on this bus.
 
                           Data Port A is used for communication with the Serial Bus.  Bits 5 and
@@ -3127,7 +3127,7 @@ $DD00-$DD01               CIA #2 Data Ports A and B
                           The advanced features of the CIA chip make almost any type of
                           interfacing application possible, and in the near future we will
                           probably see many interesting applications for the User Port on the
-                          64.  A pin description of tthe User Port connector is provided below:
+                          64.  A pin description of the User Port connector is provided below:
 
                           | User Port Pin | CIA Line | RS-232 DB-25 Pin |      Description				    |
                           |---------------|----------|------------------|--------------------------------     ----------------|
@@ -3216,7 +3216,7 @@ $DD00-$DD01               CIA #2 Data Ports A and B
                           BASIC programs do not interfere, this area is wide open for sprite
                           shapes, character graphics, and bitmap graphics.
 
-                          The drawbacks to useing this bank are the unavailability of the
+                          The drawbacks to using this bank are the unavailability of the
                           character ROM and the limitation on BASIC program space (as little as
                           14K).  The absence of the character ROM is a relatively minor
                           nuisance, because you can always switch in the ROM and copy any or all
@@ -3312,7 +3312,7 @@ $DD00-$DD01               CIA #2 Data Ports A and B
                           Below is a sample program which switches to Bank 3.  It includes a
                           machine language transfer routine to move the ROM character set to
                           RAM, and a short interrupt routine to correct the RESTORE key problem.
-                          After the switch is made, a loop isused to POKE characters into the
+                          After the switch is made, a loop is used to POKE characters into the
                           new screen memory area.  Next, the character data is slowly erased, to
                           show that the character set is now in RAM.  Then, a loop is used to
                           read the locations of the character set, and write to the same
@@ -3561,7 +3561,7 @@ $DE00-$DEFF               Reserved for I/O Expansion
 $DF00-$DFFF               CIA #2 Register Images
 
                           This range of locations is not used directly by the 64's internal
-                          hardward, but is accessible via pin 10 of the Expansion Port.  One
+                          hardware, but is accessible via pin 10 of the Expansion Port.  One
                           possible use for this I/O memory that Commodore has mentioned is an
                           inexpensive parallel disk drive (which presumable would be much faster
                           than the current serial model).

--- a/src/c64mem/c64mem_64map.txt
+++ b/src/c64mem/c64mem_64map.txt
@@ -55,7 +55,7 @@ $0017-$0018  LASTPT  Last temporary String Address.
 $0019-$0021  TEMPST  Stack for temporary Strings.
 $0022-$0025  INDEX   Utility Pointer Area.
 $0022-$0023  INDEX1  First Utility Pointer.
-$0024-$0025  INDEX2  Secong Utility Pointer.
+$0024-$0025  INDEX2  Second Utility Pointer.
 $0026-$002A  RES     Floating point product of Multiply and
                      Divide.
 $002B-$002C  TXTTAB  Pointer: Start of BASIC Text Area ($0801).
@@ -83,7 +83,7 @@ $004B-$004C  VARTXT  Temporary storage for TXTPTR during READ,
                      INPUT and GET.
 $004D        OPMASK  Mask used during FRMEVL.
 $004E-$0052  TEMPF3  Temporary storage for FLPT value.
-$0053        FOUR6   Length of String Variable during Garbege
+$0053        FOUR6   Length of String Variable during Garbage
                      collection.
 $0054-$0056  JMPER   Jump Vector used in Function Evaluation -
                      JMP followed by Address ($4C,$LB,$MB).

--- a/src/c64mem/c64mem_jb.txt
+++ b/src/c64mem/c64mem_jb.txt
@@ -120,7 +120,7 @@ $00B5        NXTBIT  Tp EOT/RS232 next bit to send
 $00B6        RODATA  Read character error/outbyte buf
 $00B7        FNLEN   # characters in file name
 $00B8        LA      Current logical file
-$00B9        SA      Current secndy address
+$00B9        SA      Current secondary address
 $00BA        FA      Current device
 $00BB-$00BC  FNADR   Pointer to file name
 $00BD        ROPRTY  Wr shift word/Rd input char
@@ -144,7 +144,7 @@ $00D1-$00D2  PNT     Pointer to screen line
 $00D3        PNTR    Position of cursor on above line
 $00D4        QTSW    0 = direct cursor, else programmed
 $00D5        LNMX    Current screen line length
-$00D6        TBLX    Row where curosr lives
+$00D6        TBLX    Row where cursor lives
 $00D7        DATA    Last inkey/checksum/buffer
 $00D8        INSRT   # of INSERTs outstanding
 $00D9-$00F2  LDTB1   Screen line link table

--- a/src/c64mem/c64mem_mapc64.txt
+++ b/src/c64mem/c64mem_mapc64.txt
@@ -53,7 +53,7 @@ $0000        D6510   6510 On-Chip I/O DATA Direction Register
                      location 1) can be written to by peripheral devices.  If the bit is
                      set to 0, it indicates the direction of data flow as Input, which
                      means that the corresponding bit of the I/O port will be affected by
-                     peripheral defices.  If the bit is set to 1, it indicates Output.  On
+                     peripheral devices.  If the bit is set to 1, it indicates Output.  On
                      the 64, only Bits 0-5 are significant.  On power-up, this register is
                      set to 239 ($EF), which indicates that all bits, except for Bit 4
                      (which senses the cassette switch), are set up for Output.
@@ -167,7 +167,7 @@ $0001        R6510   6510 On-Chip I/O Port
                      CIA's), o I/O can occur when this ROM is switched in.
                      
                      The ability to switch in the character generator ROM is very useful to
-                     the programmer who wishes to expirement with user-defined characters.
+                     the programmer who wishes to experiment with user-defined characters.
                      Modified character graphics is one of the  more powerful graphics
                      tools available, but often the user will not want to redefine a whole
                      character set at one time.  By reading the character ROM and
@@ -202,7 +202,7 @@ $0001        R6510   6510 On-Chip I/O Port
                      expansion cartridges which are connected to the expansion port, and
                      these can change the memory map.
                      
-                     Two lines located on the exapansion port are called GAME and EXROM.
+                     Two lines located on the expansion port are called GAME and EXROM.
                      When used in conjunction with the software-controlled lines noted
                      above, these two hardware lines can enable cartridge ROM to replace
                      various segments of ROM and/or RAM.
@@ -216,7 +216,7 @@ $0001        R6510   6510 On-Chip I/O Port
                      mode is entered, which mimics the specification of the ill-fated Max
                      Machine, a game machine which Commodore never produced for sale in the
                      U.S.  In this mode, only the first 6K of RAM are used, there is no
-                     access to the character ROM, and graphics data such as charactger
+                     access to the character ROM, and graphics data such as character
                      dot-data is mapped down from 57344 ($E000) to 8192 ($2000).  Further
                      hardware information may be obtained from the Commodore 64
                      Programmer's Reference Guide.
@@ -514,7 +514,7 @@ $0017-$0018  LASTPT  Pointer to the Address of the Last String in the Temporary 
 $0019-$0021  TEMPST  Descriptor Stack for Temporary Strings
                      
                      The temporary string descriptor stack contains information about
-                     temporary strings which hve not yet been assigned to a string
+                     temporary strings which have not yet been assigned to a string
                      variable.  An examples of such a temporary string is the literal
                      string "HELLO" in the statement PRINT "HELLO".
                      
@@ -558,7 +558,7 @@ $002B-$002C  TXTTAB  Pointer to the Start of BASIC Program Text
                      Such reconfiguring can be helpful in transferring programs from the 64
                      to the PET, or vice versa.  Since the 64 automatically relocates BASIC
                      program text, it can load and list PET programs even though the
-                     program file indicates a loading addresss that is different from the
+                     program file indicates a loading address that is different from the
                      64 start of BASIC.  The PET does not have this automatic relocation
                      feature, however, and it loads all BASIC programs at the two-byte
                      address indicated at the beginning of the disk or tape file.
@@ -573,7 +573,7 @@ $002B-$002C  TXTTAB  Pointer to the Start of BASIC Program Text
                      2.  Raising the lowest location used for BASIC text in order to create
                      a safe area in low memory.  For example, if you wish to use the
                      high-resolution graphics mode, you may want to put the start of screen
-                     memory at 8192 ($2000).  The high-resolution moe requires 8K of
+                     memory at 8192 ($2000).  The high-resolution mode requires 8K of
                      memory, and you cannot use the lowest 8K for this purpose because it
                      is already being used for the zero-page assignments.
                      
@@ -589,7 +589,7 @@ $002B-$002C  TXTTAB  Pointer to the Start of BASIC Program Text
                      
                      3.  Keeping two or more programs in memory simultaneously.  By
                      changing this pointer, you can keep more than one BASIC program in
-                     memory at one time, and switch back and forth betwenn them.  Examples
+                     memory at one time, and switch back and forth between them.  Examples
                      of this application can be found in COMPUTE!'s First Book of PET/CBM,
                      pages 66 and 163.
                      
@@ -604,7 +604,7 @@ $002B-$002C  TXTTAB  Pointer to the Start of BASIC Program Text
                      
                      b) You can have two programs in memory at once and use the concept in
                      (2) above to allow an easier way to create a safe area in low memory.
-                     The first program is just onw line that sets the start of BASIC
+                     The first program is just one line that sets the start of BASIC
                      pointer to the address of the second program which is located higher
                      in memory, and then runs that second program.
                      
@@ -643,7 +643,7 @@ $002D-$002E  VARTAB  Pointer to the Start of the BASIC Variable Storage Area
                      
                      A string variable will use the third byte for its length, and the
                      fourth and fifth bytes for a pointer to the address of the string
-                     text, leaving the last two bytes unused.  Note that the acrual string
+                     text, leaving the last two bytes unused.  Note that the actual string
                      text that is pointed to is located either in the part of the BASIC
                      program where the string is first assigned a value, or in the string
                      text storage area pointed to by location 51 ($0033).
@@ -779,7 +779,7 @@ $0035-$0036  FRESPC  Temporary Pointer for Strings
 $0037-$0038  MEMSIZ  Pointer to the Highest Address Used by BASIC
                      
                      The power-on/reset routine tests each byte of RAM until it comes to
-                     the BASIC ROM, and sets this pointer to the adress of the highest byte
+                     the BASIC ROM, and sets this pointer to the address of the highest byte
                      of consecutive RAM found (40959, $9FFF).
                      
                      There are two circumstances under which this pointer may be changed
@@ -934,7 +934,7 @@ $004B-$004C  OPPTR   Math Operator Table Displacement
 $004D        OPMASK  Mask for Comparison Operation
                      
                      The expression evaluation routine creates a mask here which lets it
-                     know whether the current comparieson operation is a less-than (1),
+                     know whether the current comparison operation is a less-than (1),
                      equals (2), or greater-than (4) comparison.
                      
 $004E-$004F  DEFPNT  Pointer to the Current FN Descriptor
@@ -1093,7 +1093,7 @@ $0073-$008A  CHRGET  Subroutine: Get Next BASIC Text Character
                      Diversion of the CHRGET routine for this purpose is generally referred
                      to as a wedge.
                      
-                     Since a wedge can greatly slow down execution speed, mose of the time
+                     Since a wedge can greatly slow down execution speed, most of the time
                      it is set up so that it performs its preprocessing functions only when
                      in direct or immediate mode.  The most well-known example of such a
                      wedge is the "Universal DOS Support" program that allows easier
@@ -1107,7 +1107,7 @@ $0073-$008A  CHRGET  Subroutine: Get Next BASIC Text Character
                          119 $77           INC TXTPTR+1 ; increment high byte of TXTPTR
                          121 $79   CHRGOT  LDA          ; load byte from where TXTPTR points
                                                         ; entry here does not update TXTPTR,
-                                                        ; allowing you to readl the old byte again
+                                                        ; allowing you to read the old byte again
                          122 $7A   TXTPTR  $0207        ; pointer is really the LDA operand
                                                         ; TXTPTR+1 points to 512-580 ($0200-$0250)
                                                         ; when reading from the input buffer
@@ -1143,7 +1143,7 @@ $0073-$008A  CHRGET  Subroutine: Get Next BASIC Text Character
                      
                      While the wedge is a good, quick technique for adding new commands, a
                      much more elegant method exists for accomplishing this task on the
-                     VIC-20 and 64 withouth slowing BASIC down to the extent that the wedge
+                     VIC-20 and 64 without slowing BASIC down to the extent that the wedge
                      does.  See the entries for the BASIC RAM vector area at 768-779
                      ($0300-$030B) for more details.
                      
@@ -1405,7 +1405,7 @@ $00A7        INBIT   RS-232 Input Bits/Cassette Temporary Storage Area
                      This location is used to temporarily store each bit of serial data
                      that is received, as well as for miscellaneous tasks by tape I/O.
                      
-$00A8        BITCI   RS-232 Input Bit Count/Cassete Temporary Storage
+$00A8        BITCI   RS-232 Input Bit Count/Cassette Temporary Storage
                      
                      This location is used to count the number of bits of serial data that
                      has been received.  This is necessary so that the serial routines will
@@ -1426,7 +1426,7 @@ $00AA        RIDATA  RS-232 Input Byte Buffer/Cassette Temporary Storage
                      received character should be treated as data or as a synchronization
                      character.
                      
-$00AB        RIPRTY  RS-232 Input Parity/Cassete Leader Counter
+$00AB        RIPRTY  RS-232 Input Parity/Cassette Leader Counter
                      
                      This location is used to help detect if data was lost during RS-232
                      transmission, or if a tape leader is completed.
@@ -1557,7 +1557,7 @@ $00B9        SA      Current Secondary Address
                      should be relocating or nonrelocating.
                      
                      When the 1515 or 1525 Printer is opened with a secondary address of 7,
-                     the uppercase/lowercase character set is used.  If it is openend with
+                     the uppercase/lowercase character set is used.  If it is opened with
                      a secondary address of 0, or without a secondary address, the
                      uppercase/graphics character set will be used.
                      
@@ -1640,7 +1640,7 @@ $00C1-$00C2  STAL    I/O Start Address
                      
 $00C5        LSTX    Matrix Coordinate of Last Key Pressed, 64=None Pressed
                      
-                     During every normal IRQ interrput this location is set with the value
+                     During every normal IRQ interrupt this location is set with the value
                      of the last keypress, to be used in keyboard debouncing.  The
                      Operating System can check if the current keypress is the same as the
                      last one, and will not repeat the character if it is.
@@ -1652,7 +1652,7 @@ $00C5        LSTX    Matrix Coordinate of Last Key Pressed, 64=None Pressed
                      
 $00C6        NDX     Number of Characters in Keyboard Buffer (Queue)
                      
-                     The value here indicates the number of charracters waiting in the
+                     The value here indicates the number of characters waiting in the
                      keyboard buffer at 631 ($0277).  The maximum number of characters in
                      the keyboard buffer at any one time is determined by the value in
                      location 649 ($0289), which defaults to 10.
@@ -1684,7 +1684,7 @@ $00C6        NDX     Number of Characters in Keyboard Buffer (Queue)
                      try to INPUT a string that has a comma or colon, the INPUT will read
                      only up to that character and issue an EXTRA IGNORED error message.
                      You can avoid this by entering the input string in quotes, but this
-                     places on the user the burder of remembering the quote marks.  One
+                     places on the user the burden of remembering the quote marks.  One
                      solution is to use the statements:
                      
                          POKE 198,3:POKE 631,34: POKE 632,34: POKE 633,20
@@ -1701,7 +1701,7 @@ $00C7        RVS     Flag: Print Reverse Characters? 0=No
                      
                      When the [CTRL][RVS-ON] characters are printer (CHR$(18)), this flag
                      is set to 18 ($12), and the print routines will add 128 ($80) to the
-                     screen code of each character which is printed, so that the caracter
+                     screen code of each character which is printed, so that the character
                      will appear on the screen with its colors reversed.
                      
                      POKEing this location directly with a nonzero number will achieve the
@@ -1709,7 +1709,7 @@ $00C7        RVS     Flag: Print Reverse Characters? 0=No
                      location are returned to 0 not only upon entry of a [CTRL][RVS-OFF]
                      character (CHR$(146)), but also at every carriage return.  When this
                      happens, characters printed thereafter appear with the normal
-                     comination of colors.
+                     combination of colors.
                      
 $00C8        INDX    Pointer: End of Logical Line for Input
                      
@@ -1728,8 +1728,8 @@ $00C9-$00CA          Cursor X,Y Position at Start of Input
                      1-25.  Depending on the length of the logical line, the cursor column
                      may be from 1-40 or 1-80.
                      
-                     For a more detailed exaplanation of logical lines, see the description
-                     of the screen line link talbe, 217 ($00D9).
+                     For a more detailed explanation of logical lines, see the description
+                     of the screen line link table, 217 ($00D9).
                      
 $00CB        SFDX    Matrix Coordinate of Current Key Pressed
                      
@@ -1843,7 +1843,7 @@ $00CE        GDBLN   Character Under Cursor
                      of the character that is located at the cursor position, so that it
                      may be restored when the cursor moves on.
                      
-$00CF        BLNON   Flag: Was Last Curson Blink on or off?
+$00CF        BLNON   Flag: Was Last Cursor Blink on or off?
                      
                      This location keeps track of whether, during the current cursor blink,
                      the character under the cursor was reversed, or was restored to
@@ -1885,7 +1885,7 @@ $00D4        QTSW    Flag: Editor in Quote Mode? 0=No
                      The exception to this rule is the DELETE key, which will function
                      normally within quote mode.  The only way to print a character which
                      is equivalent to the DELETE key is by entering insert mode (see
-                     loctaion 216 ($00D8)).  Quote mode may be exited by printing a closing
+                     location 216 ($00D8)).  Quote mode may be exited by printing a closing
                      quote, or by hitting the RETURN or SHIFT-RETURN keys.
                      
                      Sometimes, it would be handy to be able to escape from quote mode or
@@ -1976,7 +1976,7 @@ $00D9-$00F2  LDTB1   Screen Line Link Table/Editor Temporary Storage
                      
 $00F3-$00F4  USER    Pointer to the Address of the Current Screen Color RAM Location
                      
-                     This poitner is synchronized with the pointer to the address of the
+                     This pointer is synchronized with the pointer to the address of the
                      first byte of screen RAM for the current line kept in location 209
                      ($00D1).  It holds the address of the first byte of color RAM for the
                      corresponding screen line.
@@ -2074,7 +2074,7 @@ $0100-$013E  BAD     Tape Input Error Log
                      
                      Each tape block is saved twice consecutively, in order to minimize
                      loss of data from transmission errors.  These 62 bytes serve as
-                     indices of which bytes in the tape block were not received corectly
+                     indices of which bytes in the tape block were not received correctly
                      during the first transmission, so that corrections might be made on
                      the second pass.
 
@@ -2118,7 +2118,7 @@ $0200-$0258  BUF     BASIC Line Editor Input Buffer
                      
                      This same area is also used to store data which is received via the
                      INPUT and GET commands.  This explains why these commands are illegal
-                     in immediate mode--they must use the same buffer space that is
+                     in immediate mode -- they must use the same buffer space that is
                      required by the immediate mode statement itself.
                      
                      It is interesting to note that this buffer is 89 bytes long.  The
@@ -2447,7 +2447,7 @@ $028C        DELAY   Counter for Timing the Delay Until the First Key Repeat Beg
                      there reaches 0.  Thus a total of 22/60, or approximately 1/3, second
                      will elapse before the first repeat of a key.  The value here will be
                      held to 0 after the first repeat, so that subsequent keystroke
-                     repititions occur much more quickly.
+                     repetitions occur much more quickly.
                      
 $028D        SHFLAG  Flag: SHIFT/CTRL/Logo Keypress
                      
@@ -2766,7 +2766,7 @@ $0295-$0296  M51AJB  RS-232: Nonstandard Bit Timing
                      These locations are provided for storing a nonstandard user-defined
                      baud rate, to be used when the low nybble of the control register at
                      659 ($0293) is set to 0.  They were presumable provided to conform to
-                     the nodel of the 6551 UART device, which allows a nonstandard baud
+                     the model of the 6551 UART device, which allows a nonstandard baud
                      rate to be generated from an external reference crystal.  However, the
                      software emulation of that feature is not provided in the current
                      version of the Kernal, and thus these locations are currently
@@ -2927,7 +2927,7 @@ $02A7-$02FF          Unused
                      If the VIC-II ship is using the bottom 16K for graphics and memory
                      (the default setting when the system is turned on), this is one of the
                      few free areas available for storing sprite or character data.
-                     Locaitons 704-767 could be used for sprite data block number 11,
+                     Locations 704-767 could be used for sprite data block number 11,
                      without interfering with BASIC program text or variables.
                      
 $0300-$030B          BASIC Indirect Vector Table
@@ -3014,7 +3014,7 @@ $0308-$0309  IGONE   Vector to the Routine That Executes the Next BASIC Program 
 $030A-$030B  IEVAL   Vector to the Routine That Evaluates a Single-Term Arithmetic
                      Expression
                      
-                     This vector points to the address of the EVAL routinea t 44678 ($AE86)
+                     This vector points to the address of the EVAL routine at 44678 ($AE86)
                      which, among other things, is used to evaluate BASIC functions such as
                      INT and ABS.
                      
@@ -3103,7 +3103,7 @@ $0311-$0312  USRADD  Address of USR Routine (Low Byte First)
                      These locations contain the target address of the USR command.  They
                      are initialized by the Operating System to point to the BASIC error
                      message handler routine, so that if you try to execute a USR call
-                     without changing these values, you wil receive an ILLEGAL QUANTITY
+                     without changing these values, you will receive an ILLEGAL QUANTITY
                      error message.
                      
                      In order to successfully execute a USR call, you must first POKE in
@@ -3139,7 +3139,7 @@ $0311-$0312  USRADD  Address of USR Routine (Low Byte First)
                      the high byte used to indicate the sign.
                      
                      To pass a value back through the USR function, you need to place the
-                     number into FAC1.  To conert a signed integer to floating point
+                     number into FAC1.  To convert a signed integer to floating point
                      format, place the high byte into the Accumulator (.A), the low byte
                      into the .Y register, and jump through the vector at locations 5-6
                      with a JMP ($0005) instruction.  The floating point result will be
@@ -3357,7 +3357,7 @@ $033C-$03FB  TBUFFR  Cassette I/O Buffer
                      program will always load at the address specified in the header.  A
                      relocatable program will load at the current start of BASIC address
                      unless the LOAD statement uses a secondary address of 1, in which case
-                     it will also be loaded at the addrss specified in the header.
+                     it will also be loaded at the address specified in the header.
                      
                      You should note that a program file uses the cassette buffer only to
                      store the header block.  Actual program data is transferred directly
@@ -3369,7 +3369,7 @@ $033C-$03FB  TBUFFR  Cassette I/O Buffer
                      data blocks start with an identifier byte of 2.  These blocks contain
                      the actual data byte written by the PRINT #1 command, and read by the
                      GET #1 and INPUT #1 commands.  Unlike the body of a program file,
-                     these blocks are temporarily stored in the cassette byffer when being
+                     these blocks are temporarily stored in the cassette buffer when being
                      written or read.
                      
                      An identifier byte of 5 indicates that this block is the logical end

--- a/src/c64mem/c64mem_prg.txt
+++ b/src/c64mem/c64mem_prg.txt
@@ -40,7 +40,7 @@ $0008        ENDCHR  Flag: Scan for Quote at End of String
 $0009        TRMPOS  Screen Column From Last TAB
 $000A        VERCK   Flag: 0 = Load, 1 = Verify
 $000B        COUNT   Input Buffer Pointer / No. of Subscripts
-$000C        DIMFLG  Flag: Default Array DiMension
+$000C        DIMFLG  Flag: Default Array Dimension
 $000D        VALTYP  Data Type: $FF = String, $00 = Numeric
 $000E        INTFLG  Data Type: $80 = Integer, $00 = Floating
 $000F        GARBFL  Flag: DATA scan/LIST quote/Garbage Coll

--- a/src/c64mem/c64mem_src.txt
+++ b/src/c64mem/c64mem_src.txt
@@ -269,7 +269,7 @@ $0065        FACLO   Least sig byte of mantissa.
 
 $0066        FACSGN  Sign of FAC (0 or -1) when unpacked.
 
-$0067        SGNFLG  Sign of FAC is preserved bere by "FIN".
+$0067        SGNFLG  Sign of FAC is preserved here by "FIN".
 
 $0067        DEGREE  A count used by polynomials.
 
@@ -494,7 +494,7 @@ $00D3        PNTR    Pointer to column
 
 $00D4        QTSW    Quote switch
 
-$00D5        LNMX    40/80 max positon
+$00D5        LNMX    40/80 max position
 
 $00D6        TBLX
 

--- a/src/c64mem/c64mem_sta.txt
+++ b/src/c64mem/c64mem_sta.txt
@@ -290,7 +290,7 @@ $0090        STATUS  Value of ST variable, device status for serial bus and data
 
                      Serial bus bits:
 
-                     * Bit #0: Transfer direction during which the timeout occured; 0 = Input; 1 = Output.
+                     * Bit #0: Transfer direction during which the timeout occurred; 0 = Input; 1 = Output.
                      * Bit #1: 1 = Timeout occurred.
                      * Bit #4: 1 = VERIFY error occurred (only during VERIFY), the file read from the device did not match that in the memory.
                      * Bit #6: 1 = End of file has been reached.
@@ -789,7 +789,7 @@ $0302-$0303  IMAIN   Execution address of BASIC idle loop.
 
                      Default: $A483.
 
-$0304-$0305  ICRNCH  Execution address of BASIC line tokenizater routine.
+$0304-$0305  ICRNCH  Execution address of BASIC line tokenizer routine.
 
                      Default: $A57C.
 
@@ -851,7 +851,7 @@ $0320-$0321  ICKOUT  Execution address of CHKOUT, routine defining file as defau
 
                      Default: $F250.
 
-$0322-$0323  ICLRCH  Execution address of CLRCHN, routine initializating input/output.
+$0322-$0323  ICLRCH  Execution address of CLRCHN, routine initializing input/output.
 
                      Default: $F333.
 

--- a/src/kernal/kernal_ct.txt
+++ b/src/kernal/kernal_ct.txt
@@ -27,7 +27,7 @@ $FF81  CINT    Setup VIC, screen values, (128: 8563)...
                     Registers Out : None.
                     Memory Changed: Screen Editor Locations.
                
-$FF84  IOINIT  Initializes pertinant display and i/o devices
+$FF84  IOINIT  Initializes pertinent display and i/o devices
                
                     Registers In  : C64: None. | C128: $0A04/bit 7
                                                |          0 - Full Setup.
@@ -109,7 +109,7 @@ $FFA2  SETMO
                
                     This is a routine who's code never made it into any versions
                     of the KERNAL on the C64, Vic-20 and C128.  Thus it is of no
-                    pratical use.
+                    practical use.
                
 $FFA5  ACPTR   Get byte from current talker.
                
@@ -164,7 +164,7 @@ $FFBA  SETLFS  Set logical file #, device #, secondary # for I/O.
                     Registers Out : None.
                     Memory Changed: None.
                
-$FFBD  SETNAM  Sets pointer to filename in preperation for OPEN.
+$FFBD  SETNAM  Sets pointer to filename in preparation for OPEN.
                
                     Registers In  : .A = string length, .XY = string address.
                     Registers Out : None.
@@ -210,7 +210,7 @@ $FFCF  BASIN   Read character from current input channel.
                     Cassette - Returned one character a time from cassette buffer.
                     Rs-232   - Return one character at a time, waiting until 
                                character is ready.
-                    Serial   - Returned one character at time, waiting if nessc.
+                    Serial   - Returned one character at time, waiting if needed.
                     Screen   - Read from current cursor position.
                     Keyboard - Read characters as a string, then return them 
                                individually upon each call until all characters
@@ -236,7 +236,7 @@ $FFD5  LOAD    Loads file into memory (setup via SETLFS,SETNAM)..
                
 $FFD8  SAVE    Save section of memory to a file.
                
-                    Registers In  : .A = Z-page ptr to start adress
+                    Registers In  : .A = Z-page ptr to start address
                                     .XY = end address
                     Registers Out : .A = error code, .C = 1 if error.
                                     .XY = used.
@@ -281,7 +281,7 @@ $FFE7  CLALL   Close all open files and channels.
                     Registers Out : .AX used.
                     Memory Changed: None.
                     Note          : This routine does not _actually_ close the files, rather it
-                                    removes their prescense from the file tables held in memory.
+                                    removes their presence from the file tables held in memory.
                                     It's recommended to use close to close files instead of using
                                     this routine.
                

--- a/src/kernal/kernal_dh.txt
+++ b/src/kernal/kernal_dh.txt
@@ -860,7 +860,7 @@ $FFD5  LOAD    LOAD/VERIFY to RAM
                For tape LOAD/VERIFY, the LOAD routine first checks if
                the tape buffer is located in memory >= 0200. If so, it loads
                the tape buffer with a header retrieved from the tape. If a file-
-               name has been specified, a specific he,ader with this filename
+               name has been specified, a specific header with this filename
                is loaded; if there is no filename, it loads the next header on
                the tape. Only tape headers with tape identifiers of 1 or 3 are
                acceptable for LOAD/VERIFY. A tape identifier of 5 indicates
@@ -1147,7 +1147,7 @@ $FFF0  PLOT    Read or set cursor location
                
                If the carry bit is clear at entry, move the cursor to the
                specified location. The contents of the the X register determine
-               the new cursor row andthe contents of the Y register deter-
+               the new cursor row and the contents of the Y register deter-
                mine the new cursor column.
                
                If the carry bit is set at entry, read the cursor location and
@@ -1335,7 +1335,7 @@ $FFB7  READST  Read or reset status
                buffer. This allows routines to test the status so they don't
                loop waiting for data.
                
-               **Receiver Buffer Overun**: The RS-232 input buffer is full and
+               **Receiver Buffer Overrun**: The RS-232 input buffer is full and
                another byte has been received.
                
                
@@ -1708,7 +1708,7 @@ $FDF9          Set Filename Location and Number of Characters FDF9/FE49-FDFF/FE4
                **Called by**: JMP from Kernal SETNAM vector at FFBD.
                
                The location of the filename is placed in a pointer at (BB),
-               and the nurnber of characters in the filename is placed in B7.
+               and the number of characters in the filename is placed in B7.
                
                This routine sets filename information for later use of the
                Kernal routines OPEN, SAVE, and LOAD. If no filename is

--- a/src/kernal/kernal_mapc64.txt
+++ b/src/kernal/kernal_mapc64.txt
@@ -48,7 +48,7 @@ $FF81  CINT    Initialize Screen Editor and VIC-II Chip
                
 $FF84  IOINIT  Initialize CIA I/O Devices
                
-               This routine intializes the Complex Interface Adapter (CIA)
+               This routine initializes the Complex Interface Adapter (CIA)
                devices, and turns the volume of the SID chip off.  As part of this
                initialization, it sets CIA #1 Timer A to cause an IRQ interrupt every
                sixtieth of a second.
@@ -91,7 +91,7 @@ $FF8D  VECTOR  Set the RAM Vector Table from the Table Pointed to by .X and .Y
 $FF90  SETMSG  Set the Message Control Flag
                
                This routine controls the printing of error messages and control
-               messages by the Kernal.  It Bit 6 is seto to 1 (bit value of 64),
+               messages by the Kernal.  It Bit 6 is set to 1 (bit value of 64),
                Kernal control messages can be printed.  These messages include
                SEARCHING FOR, LOADING, and the like.  If Bit 6 is cleared to 0, these
                messages will not be printed (BASIC will clear this bit when a program
@@ -132,7 +132,7 @@ $FF99  MEMTOP  Read/Set Top of RAM Pointer
 $FF9C  MEMBOT  Read/Set Bottom of RAM Pointer
                
                This routine can be used to either read or set the bottom of RAM pointer.  If
-               called with the Carry flag set, the address in the pointer willbe
+               called with the Carry flag set, the address in the pointer will be
                loaded into the .X and .Y registers.  If called with the Carry flag
                cleared, the pointer will be changed to the address found in the .X
                and .Y registers.
@@ -249,7 +249,7 @@ $FFC3  CLOSE   Close a Logical I/O File
                routine.
                
                Closing an RS-232 file will de-allocate space at the top of memory for
-               the receiving and trasmit buffers.  Closing a cassette file that was
+               the receiving and transmit buffers.  Closing a cassette file that was
                opened for writing will force the last block to be written to
                cassette, even if it is not a full 192 bytes.  Closing a serial bus
                device will send an UNLISTEN command on the bus.  Remember, it is
@@ -397,7 +397,7 @@ $FFE4  GETIN   Get One Byte from the Input Device
                
                The routine jumps through a RAM vector at 810 ($32A).
                Its function is to get a character from the current input device
-               (whose device number is stored at 153 ($99)).  In practive, it
+               (whose device number is stored at 153 ($99)).  In practice, it
                operates identically to the CHRIN routine below for all devices except
                for the keyboard.  If the keyboard is the current input device, this
                routine gets one character from the keyboard buffer at 631 ($277).  It

--- a/src/kernal/kernal_mlr.txt
+++ b/src/kernal/kernal_mlr.txt
@@ -78,7 +78,7 @@ $FFC9  CHKOUT  CHKOUT
                The routine sets the output channel (location $9A) to the
                device number for the specified file. If the device is RS-232
                (device number 2), the routine also enables the CLA #2 inter-
-               rupts for RS-232 transmission. fi a serial device (device num-
+               rupts for RS-232 transmission. If a serial device (device num-
                ber 4 or greater) is specified, the device is also made a listener
                on the serial bus.
 
@@ -325,11 +325,11 @@ $FF84  IOINIT  IOINIT
 
                This routine initializes the CIA chips' registers to their default
                values, along with related RAM locations. All processor reg-
-               isters are affected. For the 128, the routine also initiatizes the
+               isters are affected. For the 128, the routine also initializes the
                VIC and VDC chip registers (a step which is part of the Kernal
                CINT routine on the 64). In addition, the 128 routine sets all
                SID chip registers to zero and calls the Kernal DLCHR routine
-               to initiahze the character set for the 80-column chip.
+               to initialize the character set for the 80-column chip.
 
 $FFB1  LISTEN  LISTEN
 
@@ -351,7 +351,7 @@ $FFD5  LOAD    LOAD
                routines for details.
 
                SETLFS establishes the device number and secondary ad-
-               dress for the operation. fThe logical file number isn't significant
+               dress for the operation. The logical file number isn't significant
                for loading or verifying.) The secondary-address value deter-
                mines whether the load/verify will be absolute or relocating.
                If bit 0 of the secondary address is %0 (if the value is 0 or any
@@ -375,7 +375,7 @@ $FFD5  LOAD    LOAD
                The status-register carry bit will be clear upon return if
                the file was successfully loaded, or set if an error occurred or if
                the RUN/STOP key was pressed to abort the load. When
-               carry is se t upon return, the accumulator will hold a Kernal er-
+               carry is set upon return, the accumulator will hold a Kernal er-
                ror-code value indicating the problem. Possible error codes in-
                clude 4 (file was not found), 5 (device was not present), 8 (no
                name was specified for a serial load), 9 (an illegal device num-
@@ -478,7 +478,7 @@ $FFDE  RDTIM   RDTIM
                reset, or the number of jiffies since midnight if the dock value
                has been set. The low byte of the clock value (location $A2) is
                returned in .A, the middle byte (location $A1) in .X, and the
-               high byte loocation $A0) in .Y.
+               high byte location $A0) in .Y.
 
 $FFB7  READST  READST
 
@@ -502,7 +502,7 @@ $FFB7  READST  READST
                |     |         |                       |                                       |                          |
                | 5   |  32/$20 |                       | checksum mismatch                     |                          |
                | 6   |  64/$40 | EOI (end of file)     | end of file                           | DSR missing              |
-               | 7   | 128/$80 | device nol present    | end of tape                           | break                    |
+               | 7   | 128/$80 | device not present    | end of tape                           | break                    |
   
 $FF8A  RESTOR  RESTOR
 
@@ -660,7 +660,7 @@ $FFB4  TALK    TALK
 $FF96  TKSA    TKSA
 
                This low-level serial 1/0 routine sends a secondary address to
-               a device which has previously been commanded to taLk. The
+               a device which has previously been commanded to talk. The
                success of the operation will be indicated by the value in the
                serial status flag upon return. (See READST for details.)
 
@@ -670,7 +670,7 @@ $FFEA  UDTIM   UDTIM
                keyboard column containing the RUN/STOP key. (The 128
                version of the routine also decrements a countdown timer.)
                This routine is normally called every 1 /60 second as part of
-               the standard lRQ service routine.
+               the standard IRQ service routine.
 
 $FFAE  UNLSN   UNLSN
 
@@ -704,7 +704,7 @@ $FF53  BOOT_CALL BOOT_CALL
                number—not the actual drive number. The single drive in
                1541 and 1571 units is drive 0; in this case, use 48, the charac-
                ter code for zero. If the specified drive is not present or is
-               tumed off, or if the disk in the drive does not contain a valid
+               turned off, or if the disk in the drive does not contain a valid
                boot sector, the routine will return with the status-register
                carry bit set. If a boot sector is found, it will be loaded into
                locations $0B00-$0BFF. Additional boot sectors may be loaded

--- a/src/kernal/kernal_pm.txt
+++ b/src/kernal/kernal_pm.txt
@@ -166,7 +166,7 @@ $FFB1  LISTEN  Command devices on serial bus to LISTEN.
                
 $FFD5  LOAD    Load RAM from a device.
 
-               LOAD. The computer will perform either the LOAD or the VERIFY command. If the ac cumulator is a 1, then LOAD; if 0, then verify.
+               LOAD. The computer will perform either the LOAD or the VERIFY command. If the accumulator is a 1, then LOAD; if 0, then verify.
                
                    ;Load a program into memory.
                         LDA #$08


### PR DESCRIPTION
Semi-automatically* removed some typos from

src/6502/cpu_6502.txt
src/6502/cpu_65ce02.txt
src/c64disasm/c64disasm_en.txt
src/c64disasm/c64disasm_mm.txt
src/c64disasm/c64disasm_mn.txt
src/c64disasm/c64disasm_sc.txt
src/c64io/c64io_mapc64.txt
src/c64mem/c64mem_64map.txt
src/c64mem/c64mem_jb.txt
src/c64mem/c64mem_mapc64.txt
src/c64mem/c64mem_prg.txt
src/c64mem/c64mem_src.txt
src/c64mem/c64mem_sta.txt
src/kernal/kernal_ct.txt
src/kernal/kernal_dh.txt
src/kernal/kernal_mapc64.txt
src/kernal/kernal_mlr.txt
src/kernal/kernal_pm.txt

*: iterating hunspell, populating a custom dictionary with the words to keep and checking match between text and code