### PR TITLE
fix incorrect register names

### DIFF
--- a/src/c64io/c64io_mapc64.txt
+++ b/src/c64io/c64io_mapc64.txt
@@ -365,7 +365,7 @@ $D010        MSIGX        Most Significant Bits of Sprites 0-7 Horizontal Positi
                           the horizontal position of the corresponding sprite to a value of 255
                           or less
 
-$D011        SCROY        Vertical Fine Scrolling and Control Register
+$D011        SCROLY       Vertical Fine Scrolling and Control Register
 
                      0-2  Fine scroll display vertically by X scan lines (0-7)
                      3    Select a 24-row or 25-row text display (1=25 rows, 0=24 rows)
@@ -807,7 +807,7 @@ $D011        SCROY        Vertical Fine Scrolling and Control Register
                           WAIT 53265,128, but BASIC is usually not fast enough to execute the
                           next statement while still in the blanking interval.
 
-$D012        RASTE        Read Current Raster Scan Line/Write Line to Compare for Raster IRQ
+$D012        RASTER       Read Current Raster Scan Line/Write Line to Compare for Raster IRQ
 
                           The Raster Compare register has two different functions, depending on
                           whether you are reading from it or writing to it.  When this register
@@ -2180,7 +2180,7 @@ $D418        SIGVOL       Volume and Filter Select Register
                      4    Select low-pass filter, 1=low-pass on
                      5    Select band-pass filter, 1=band-pass on
                      6    Select high-pass filter, 1=high-pass on
-                     7    Disconnect output of voice 4, 1=voice 3 off
+                     7    Disconnect output of voice 3, 1=voice 3 off
 
                           Bits 0-3 control the volume of all outputs.  The possible volume
                           levels range from 0 (no volume) to 15 (maximum volume).  Some level of


### PR DESCRIPTION
* *Mapping the C64* `SCROLY` register ($D011, p.129) corrected from `SCROY`
* *Mapping the C64* `RASTER` register ($D012, p.138) corrected from `RASTE`
* Change SIGVOL:7 description from voice 4 to voice 3

I am constructing an .svd (Silicon Vendor Description) file for the C64 to enable programmatic generation of a Peripheral Access Crate (a kind of hardware abstraction layer commonly used in Rust).  Memory access are performed by register name for type-safety, and I plan to cite this repository given its accessibility and machine readable goals as the source of truth for register names.

Thanks for pulling all this together--this is a fantastic resource!